### PR TITLE
31 randomselection multiindexed

### DIFF
--- a/docs/user_guide/available_classes.rst
+++ b/docs/user_guide/available_classes.rst
@@ -113,6 +113,7 @@ List
     geometric_mean.GeometricMeanNormalization
     total_counts.TotalCountsNormalization
     random_selection.RandomSelection
+    random_selection.TaxonomyRandomSelection
 
 .. _av_plot:
 

--- a/moonstone/normalization/counts/random_selection.py
+++ b/moonstone/normalization/counts/random_selection.py
@@ -26,7 +26,7 @@ class RandomSelection(BaseNormalization):
         if threshold is not None:
             self.threshold = threshold
         else:
-            self.threshold = self.df.sum().min()
+            self.threshold = int(self.df.sum().min())
         # Filters out samples below the threshold
         self.samples_to_remove = self.raw_df.columns[self.raw_df.sum() < self.threshold]
         if not self.samples_to_remove.empty:
@@ -35,7 +35,7 @@ class RandomSelection(BaseNormalization):
     def _randomly_select_counts(self, column_name: str):
         np.random.seed(self.random_seed)  # set the random seed
         counts = self.df[column_name]
-        if counts.sum() <= self.threshold:
+        if counts.sum() <= self.threshold + 1:
             return counts
         probabilities = counts / counts.sum()
         new_counts = np.unique(
@@ -54,7 +54,7 @@ class RandomSelection(BaseNormalization):
                 logger.info(f"{cpt}/{total} done so far...")
         logger.info(f"[Done] {cpt}/{total}.")
         normalized_df.columns = self.df.columns
-        return normalized_df.fillna(0).astype(int)
+        return normalized_df.fillna(0).astype(float)
 
 
 class TaxonomyRandomSelection(RandomSelection):

--- a/tests/normalization/counts/test_random_selection.py
+++ b/tests/normalization/counts/test_random_selection.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 import pandas as pd
 
 from moonstone.normalization.counts.random_selection import (
-    RandomSelection
+    RandomSelection, TaxonomyRandomSelection
 )
 
 
@@ -16,7 +16,7 @@ class TestRandomSelection(TestCase):
             [1, 25, 1, 25],
         ]
         self.column_names = ['Sample_1', 'Sample_2', 'Sample_3', 'Sample_4']
-        self.index = ["Gen_1", 'Gen_2', "Gen_3"]
+        self.index = ['Gen_1', 'Gen_2', 'Gen_3']
         self.raw_df = pd.DataFrame(self.raw_data, columns=self.column_names, index=self.index)
 
     def test_normalize_default_threshold(self):
@@ -40,7 +40,6 @@ class TestRandomSelection(TestCase):
         pd.testing.assert_frame_equal(tested_normalization.normalized_df, expected_df)
 
     def test_normalize_threshold_100(self):
-        # Define what we expect here, do we want to filter out instead below threshold?
         expected_data = [
             [100, 75],
             [0, 0],
@@ -49,4 +48,61 @@ class TestRandomSelection(TestCase):
         expected_columns = ['Sample_1', 'Sample_4']
         expected_df = pd.DataFrame(expected_data, columns=expected_columns, index=self.index)
         tested_normalization = RandomSelection(self.raw_df, threshold=100, random_seed=2935)
+        pd.testing.assert_frame_equal(tested_normalization.normalized_df, expected_df)
+
+    def test_normalize_threshold_150(self):
+        expected_data = [
+            [150],
+        ]
+        expected_columns = ['Sample_1']
+        expected_df = pd.DataFrame(expected_data, columns=expected_columns, index=['Gen_1'])
+        tested_normalization = RandomSelection(self.raw_df, threshold=150, random_seed=2935)
+        pd.testing.assert_frame_equal(tested_normalization.normalized_df, expected_df)
+
+
+class TestTaxonomyRandomSelection(TestCase):
+
+    def setUp(self):
+        self.raw_data = [
+            [199, 1, 48, 75],
+            [0, 24, 1, 0],
+            [1, 25, 1, 25],
+        ]
+        self.column_names = ['Sample_1', 'Sample_2', 'Sample_3', 'Sample_4']
+        tuples = list(zip(*[
+            ['group_1', 'group_1', 'group_2'],
+            ['Gen_1', 'Gen_2', 'Gen_3']
+        ]))
+        self.index = pd.MultiIndex.from_tuples(tuples, names=['first', 'second'])
+        self.raw_df = pd.DataFrame(self.raw_data, columns=self.column_names, index=self.index)
+
+    def test_normalize_default_threshold(self):
+        expected_data = [
+            [50, 1, 48, 40],
+            [0, 24, 1, 0],
+            [0, 25, 1, 10],
+        ]
+        expected_df = pd.DataFrame(expected_data, columns=self.column_names, index=self.index)
+        tested_normalization = TaxonomyRandomSelection(self.raw_df, random_seed=2935)
+        pd.testing.assert_frame_equal(tested_normalization.normalized_df, expected_df)
+
+    def test_normalize_threshold_20(self):
+        expected_data = [
+            [20, 0, 20, 16],
+            [0, 9, 0, 0],
+            [0, 11, 0, 4],
+        ]
+        expected_df = pd.DataFrame(expected_data, columns=self.column_names, index=self.index)
+        tested_normalization = TaxonomyRandomSelection(self.raw_df, threshold=20, random_seed=2935)
+        pd.testing.assert_frame_equal(tested_normalization.normalized_df, expected_df)
+
+    def test_normalize_threshold_100(self):
+        expected_data = [
+            [100, 75],
+            [0, 0],
+            [0, 25],
+        ]
+        expected_columns = ['Sample_1', 'Sample_4']
+        expected_df = pd.DataFrame(expected_data, columns=expected_columns, index=self.index)
+        tested_normalization = TaxonomyRandomSelection(self.raw_df, threshold=100, random_seed=2935)
         pd.testing.assert_frame_equal(tested_normalization.normalized_df, expected_df)

--- a/tests/normalization/counts/test_random_selection.py
+++ b/tests/normalization/counts/test_random_selection.py
@@ -25,7 +25,7 @@ class TestRandomSelection(TestCase):
             [0, 24, 1, 0],
             [0, 25, 1, 10],
         ]
-        expected_df = pd.DataFrame(expected_data, columns=self.column_names, index=self.index)
+        expected_df = pd.DataFrame(expected_data, columns=self.column_names, index=self.index).astype(float)
         tested_normalization = RandomSelection(self.raw_df, random_seed=2935)
         pd.testing.assert_frame_equal(tested_normalization.normalized_df, expected_df)
 
@@ -35,7 +35,7 @@ class TestRandomSelection(TestCase):
             [0, 9, 0, 0],
             [0, 11, 0, 4],
         ]
-        expected_df = pd.DataFrame(expected_data, columns=self.column_names, index=self.index)
+        expected_df = pd.DataFrame(expected_data, columns=self.column_names, index=self.index).astype(float)
         tested_normalization = RandomSelection(self.raw_df, threshold=20, random_seed=2935)
         pd.testing.assert_frame_equal(tested_normalization.normalized_df, expected_df)
 
@@ -46,7 +46,7 @@ class TestRandomSelection(TestCase):
             [0, 25],
         ]
         expected_columns = ['Sample_1', 'Sample_4']
-        expected_df = pd.DataFrame(expected_data, columns=expected_columns, index=self.index)
+        expected_df = pd.DataFrame(expected_data, columns=expected_columns, index=self.index).astype(float)
         tested_normalization = RandomSelection(self.raw_df, threshold=100, random_seed=2935)
         pd.testing.assert_frame_equal(tested_normalization.normalized_df, expected_df)
 
@@ -55,8 +55,24 @@ class TestRandomSelection(TestCase):
             [150],
         ]
         expected_columns = ['Sample_1']
-        expected_df = pd.DataFrame(expected_data, columns=expected_columns, index=['Gen_1'])
+        expected_df = pd.DataFrame(expected_data, columns=expected_columns, index=['Gen_1']).astype(float)
         tested_normalization = RandomSelection(self.raw_df, threshold=150, random_seed=2935)
+        pd.testing.assert_frame_equal(tested_normalization.normalized_df, expected_df)
+
+    def test_normalize_float_default_threshold(self):
+        raw_data = [
+            [199, 1.1, 48, 75],
+            [0, 24, 1, 0],
+            [1, 25, 1, 25],
+        ]
+        self.raw_df = pd.DataFrame(raw_data, columns=self.column_names, index=self.index)
+        expected_data = [
+            [50, 1.1, 48, 40],
+            [0, 24, 1, 0],
+            [0, 25, 1, 10],
+        ]
+        expected_df = pd.DataFrame(expected_data, columns=self.column_names, index=self.index).astype(float)
+        tested_normalization = RandomSelection(self.raw_df, random_seed=2935)
         pd.testing.assert_frame_equal(tested_normalization.normalized_df, expected_df)
 
 
@@ -82,7 +98,7 @@ class TestTaxonomyRandomSelection(TestCase):
             [0, 24, 1, 0],
             [0, 25, 1, 10],
         ]
-        expected_df = pd.DataFrame(expected_data, columns=self.column_names, index=self.index)
+        expected_df = pd.DataFrame(expected_data, columns=self.column_names, index=self.index).astype(float)
         tested_normalization = TaxonomyRandomSelection(self.raw_df, random_seed=2935)
         pd.testing.assert_frame_equal(tested_normalization.normalized_df, expected_df)
 
@@ -92,7 +108,7 @@ class TestTaxonomyRandomSelection(TestCase):
             [0, 9, 0, 0],
             [0, 11, 0, 4],
         ]
-        expected_df = pd.DataFrame(expected_data, columns=self.column_names, index=self.index)
+        expected_df = pd.DataFrame(expected_data, columns=self.column_names, index=self.index).astype(float)
         tested_normalization = TaxonomyRandomSelection(self.raw_df, threshold=20, random_seed=2935)
         pd.testing.assert_frame_equal(tested_normalization.normalized_df, expected_df)
 
@@ -103,6 +119,6 @@ class TestTaxonomyRandomSelection(TestCase):
             [0, 25],
         ]
         expected_columns = ['Sample_1', 'Sample_4']
-        expected_df = pd.DataFrame(expected_data, columns=expected_columns, index=self.index)
+        expected_df = pd.DataFrame(expected_data, columns=expected_columns, index=self.index).astype(float)
         tested_normalization = TaxonomyRandomSelection(self.raw_df, threshold=100, random_seed=2935)
         pd.testing.assert_frame_equal(tested_normalization.normalized_df, expected_df)

--- a/tests/parsers/counts/taxonomy/kraken2/sunbeam_kraken2.tsv
+++ b/tests/parsers/counts/taxonomy/kraken2/sunbeam_kraken2.tsv
@@ -2,4 +2,4 @@
 #OTU ID	SAMPLE_1	SAMPLE_2	Consensus Lineage
 2	5.5	6.0	k__Bacteria; p__; c__; o__; f__; g__; s__
 186826	4.3	2.1	k__Bacteria; p__Firmicutes; c__Bacilli; o__Lactobacillales; f__; g__; s__
-109790	1.0	2.0	k__Bacteria; p__Firmicutes; c__Bacilli; o__Lactobacillales; f__Lactobacillaceae; g__Lactobacillus; s__jensenii
+109790	1.0	12.0	k__Bacteria; p__Firmicutes; c__Bacilli; o__Lactobacillales; f__Lactobacillaceae; g__Lactobacillus; s__jensenii

--- a/tests/parsers/counts/taxonomy/kraken2/test_kraken2.py
+++ b/tests/parsers/counts/taxonomy/kraken2/test_kraken2.py
@@ -20,7 +20,7 @@ class TestSunbeamKraken2Parser(TestCase):
             [
                 ['Bacteria', 'Bacteria (kingdom)', 'Bacteria (kingdom)', 'Bacteria (kingdom)', 'Bacteria (kingdom)', 'Bacteria (kingdom)', 'Bacteria (kingdom)', 2, 5.5, 6.0],  # noqa
                 ['Bacteria', 'Firmicutes', 'Bacilli', 'Lactobacillales', 'Lactobacillales (order)', 'Lactobacillales (order)', 'Lactobacillales (order)', 186826, 4.3, 2.1],  # noqa
-                ['Bacteria', 'Firmicutes', 'Bacilli', 'Lactobacillales', 'Lactobacillaceae', 'Lactobacillus', 'Lactobacillus_jensenii', 109790, 1.0, 2.0]  # noqa
+                ['Bacteria', 'Firmicutes', 'Bacilli', 'Lactobacillales', 'Lactobacillaceae', 'Lactobacillus', 'Lactobacillus_jensenii', 109790, 1.0, 12.0]  # noqa
             ],
             columns=[
                 'kingdom', 'phylum', 'class', 'order', 'family', 'genus', 'species',


### PR DESCRIPTION
## Description
Allows random selection in multiindexed dataframe.

#### Changelogs

* add TaxonomyRandomSelection to allow random selection on multiindexed dataframe

#### Issue(s)

*Indicates which issue is related to this Pull Request*

Fixes #31 

## Definition of Done

* [x]  New code is tested with unit tests
* [x]  Documentation has been updated
* [ ]  Pull Request has been revised by a maintainer of the project
