### PR TITLE
BUG : summing counts reindex_with_taxonomy

### DIFF
--- a/moonstone/utils/df_reindex.py
+++ b/moonstone/utils/df_reindex.py
@@ -26,6 +26,9 @@ class GenesToTaxonomy(TaxonomyCountsBase):
         """
         reindexation on taxonomic informations (if there are).
 
+        :param method: how to combine genes' informations of genes that have the same taxonomy. Choose 'sum' to sum the counts
+        or 'count' to only have the number of genes with this taxonomy
+
         NB: You can access the list of items without taxonomic infos by checking the .without_infos_index attributes
         """
         # merging of count dataframe with taxonomy dataframe

--- a/moonstone/utils/df_reindex.py
+++ b/moonstone/utils/df_reindex.py
@@ -14,9 +14,9 @@ class GenesToTaxonomy(TaxonomyCountsBase):
                  taxonomy_dataframe: Union[pd.Series, pd.DataFrame], taxa_column: str = 'full_tax'):
         """
         :param dataframe : genes counts dataframe
-        :param taxonomy_dataframe : index items (genes) names and with a column with the full taxonomic informations
+        :param taxonomy_dataframe : index items (genes) names and with a column with the full taxonomic information
         following the `Kraken2 <https://ccb.jhu.edu/software/kraken2/>`_ format 'k__; p__; c__; o__; f__; g__; s__
-        :param taxa_column : name of the column in taxonomy_dataframe containing the full taxonomic informations
+        :param taxa_column : name of the column in taxonomy_dataframe containing the full taxonomic information
         """
         self.df = dataframe
         self.taxonomy_df = taxonomy_dataframe
@@ -24,12 +24,13 @@ class GenesToTaxonomy(TaxonomyCountsBase):
 
     def reindex_with_taxonomy(self, method: str = 'sum'):
         """
-        reindexation on taxonomic informations (if there are).
+        reindexation on taxonomic information (if there are).
 
-        :param method: how to combine genes' informations of genes that have the same taxonomy. Choose 'sum' to sum the counts
-        or 'count' to only have the number of genes with this taxonomy
+        :param method: how to combine genes' information of genes that have the same taxonomy.
+        Choose 'sum' to sum the counts or 'count' to only have the number of genes with this taxonomy
 
-        NB: You can access the list of items without taxonomic infos by checking the .without_infos_index attributes
+        NB: You can access the list of items without taxonomic information by checking the .without_info_index
+        attributes
         """
         # merging of count dataframe with taxonomy dataframe
         new_df = self.df.merge(self.taxonomy_df[self.taxa_column], how='left',
@@ -42,9 +43,9 @@ class GenesToTaxonomy(TaxonomyCountsBase):
         if both_counts != tot:
             logger.info("If these results aren't as expected, \
 please check that the indexes (items name) of both dataframes match.")
-            logger.info("You can access the list of items without taxonomic infos \
+            logger.info("You can access the list of items without taxonomic information \
 by checking the .without_infos_index attribute.")
-        self.without_infos_index = new_df['_merge'].loc[new_df['_merge'] == 'left_only'].index
+        self.without_info_index = new_df['_merge'].loc[new_df['_merge'] == 'left_only'].index
 
         new_df = new_df.drop(['_merge'], axis=1)
         new_df[self.taxa_column] = new_df[self.taxa_column].fillna(value='k__; p__; c__; o__; f__; g__; s__')

--- a/tests/utils/test_df_reindex.py
+++ b/tests/utils/test_df_reindex.py
@@ -95,3 +95,44 @@ f__Enterococcaceae; g__Enterococcus; s__faecium']
         reindexed_df = reindexation_instance.reindexed_df
         pd.testing.assert_frame_equal(reindexed_df, df_expected)
         pd.testing.assert_index_equal(reindexation_instance.without_infos_index, pd.Index(['gene_2'], dtype='object'))
+
+    def test_reindex_with_taxonomy_summing(self):
+        df = pd.DataFrame(
+            [
+                [23, 7],
+                [15, 4],
+            ],
+            columns=['sample_1', 'sample_2'],
+            index=['gene_1', 'gene_2']  # index dtype='object'
+        )
+        df_taxo = pd.DataFrame(
+            [
+                [147802,
+                 'k__Bacteria; p__Firmicutes; c__Bacilli; o__Lactobacillales; \
+f__Lactobacillaceae; g__Lactobacillus; s__iners'],
+                [147802,
+                 'k__Bacteria; p__Firmicutes; c__Bacilli; o__Lactobacillales; \
+f__Lactobacillaceae; g__Lactobacillus; s__iners']
+            ],
+            columns=['tax_id', 'full_tax'],
+            index=['gene_1', 'gene_2']  # index dtype='object'
+        )
+        df_expected = pd.DataFrame.from_dict(
+             {
+                 'sample_1':
+                 {
+                     ('Bacteria', 'Firmicutes', 'Bacilli', 'Lactobacillales',
+                      'Lactobacillaceae', 'Lactobacillus', 'Lactobacillus_iners'): 38
+                 },
+                 'sample_2':
+                 {
+                     ('Bacteria', 'Firmicutes', 'Bacilli', 'Lactobacillales',
+                      'Lactobacillaceae', 'Lactobacillus', 'Lactobacillus_iners'): 11,
+                 }
+             }
+         )
+        df_expected.index.set_names(["kingdom", "phylum", "class", "order", "family", "genus", "species"], inplace=True)
+
+        reindexation_instance = GenesToTaxonomy(df, df_taxo)
+        reindexed_df = reindexation_instance.reindexed_df
+        pd.testing.assert_frame_equal(reindexed_df, df_expected)

--- a/tests/utils/test_df_reindex.py
+++ b/tests/utils/test_df_reindex.py
@@ -52,7 +52,7 @@ f__Enterococcaceae; g__Enterococcus; s__faecium']
         pd.testing.assert_frame_equal(reindexed_df, df_expected)
 
     def test_reindex_with_taxonomy_missing_infos(self):
-        # for now, if there aren't any taxonomic informations, the gene is dropped
+        # for now, if there aren't any taxonomic information, the gene is dropped
         df = pd.DataFrame(
             [
                 [23, 7],
@@ -92,7 +92,7 @@ f__Enterococcaceae; g__Enterococcus; s__faecium']
         reindexation_instance = GenesToTaxonomy(df, df_taxo)
         reindexed_df = reindexation_instance.reindexed_df
         pd.testing.assert_frame_equal(reindexed_df, df_expected)
-        pd.testing.assert_index_equal(reindexation_instance.without_infos_index, pd.Index(['gene_2'], dtype='object'))
+        pd.testing.assert_index_equal(reindexation_instance.without_info_index, pd.Index(['gene_2'], dtype='object'))
 
     def test_reindex_with_taxonomy_summing(self):
         df = pd.DataFrame(

--- a/tests/utils/test_df_reindex.py
+++ b/tests/utils/test_df_reindex.py
@@ -1,6 +1,5 @@
 from unittest import TestCase
 
-import numpy as np
 import pandas as pd
 
 from moonstone.utils.df_reindex import GenesToTaxonomy
@@ -53,6 +52,7 @@ f__Enterococcaceae; g__Enterococcus; s__faecium']
         pd.testing.assert_frame_equal(reindexed_df, df_expected)
 
     def test_reindex_with_taxonomy_missing_infos(self):
+        # for now, if there aren't any taxonomic informations, the gene is dropped
         df = pd.DataFrame(
             [
                 [23, 7],
@@ -78,14 +78,12 @@ f__Enterococcaceae; g__Enterococcus; s__faecium']
                 'sample_1':
                 {
                     ('Bacteria', 'Firmicutes', 'Bacilli', 'Lactobacillales',
-                     'Lactobacillaceae', 'Lactobacillus', 'Lactobacillus_iners'): 23,
-                    (np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan): 15
+                     'Lactobacillaceae', 'Lactobacillus', 'Lactobacillus_iners'): 23
                 },
                 'sample_2':
                 {
                     ('Bacteria', 'Firmicutes', 'Bacilli', 'Lactobacillales',
-                     'Lactobacillaceae', 'Lactobacillus', 'Lactobacillus_iners'): 7,
-                    (np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan): 4
+                     'Lactobacillaceae', 'Lactobacillus', 'Lactobacillus_iners'): 7
                 }
             }
         )
@@ -135,4 +133,45 @@ f__Lactobacillaceae; g__Lactobacillus; s__iners']
 
         reindexation_instance = GenesToTaxonomy(df, df_taxo)
         reindexed_df = reindexation_instance.reindexed_df
+        pd.testing.assert_frame_equal(reindexed_df, df_expected)
+
+    def test_reindex_with_taxonomy_counting(self):
+        df = pd.DataFrame(
+            [
+                [23, 7],
+                [15, 0],
+            ],
+            columns=['sample_1', 'sample_2'],
+            index=['gene_1', 'gene_2']  # index dtype='object'
+        )
+        df_taxo = pd.DataFrame(
+            [
+                [147802,
+                 'k__Bacteria; p__Firmicutes; c__Bacilli; o__Lactobacillales; \
+f__Lactobacillaceae; g__Lactobacillus; s__iners'],
+                [147802,
+                 'k__Bacteria; p__Firmicutes; c__Bacilli; o__Lactobacillales; \
+f__Lactobacillaceae; g__Lactobacillus; s__iners']
+            ],
+            columns=['tax_id', 'full_tax'],
+            index=['gene_1', 'gene_2']  # index dtype='object'
+        )
+        df_expected = pd.DataFrame.from_dict(
+             {
+                 'sample_1':
+                 {
+                     ('Bacteria', 'Firmicutes', 'Bacilli', 'Lactobacillales',
+                      'Lactobacillaceae', 'Lactobacillus', 'Lactobacillus_iners'): 2
+                 },
+                 'sample_2':
+                 {
+                     ('Bacteria', 'Firmicutes', 'Bacilli', 'Lactobacillales',
+                      'Lactobacillaceae', 'Lactobacillus', 'Lactobacillus_iners'): 1,
+                 }
+             }
+         )
+        df_expected.index.set_names(["kingdom", "phylum", "class", "order", "family", "genus", "species"], inplace=True)
+
+        reindexation_instance = GenesToTaxonomy(df, df_taxo)
+        reindexed_df = reindexation_instance.reindex_with_taxonomy(method='count')
         pd.testing.assert_frame_equal(reindexed_df, df_expected)


### PR DESCRIPTION
## Description

2 methods of reindexing : 
   * 'sum' : counts are summed 
   * 'count' : lose the quantitative informations, and only report the number of genes from this species present

#### Changelogs

* option method in reindex_with_taxonomy()

#### Issue(s)

Fixes #40 

## Definition of Done

* [x]  New code is tested with unit tests
* [ ]  Documentation has been updated
* [x]  Pull Request has been revised by a maintainer of the project
