### PR TITLE
Visualize alpha index using violin plots

### DIFF
--- a/moonstone/analysis/diversity/alpha.py
+++ b/moonstone/analysis/diversity/alpha.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from abc import ABC
+from abc import ABC, abstractmethod
 from typing import Union, Optional
 
 import pandas as pd
@@ -26,11 +26,12 @@ class AlphaDiversity(BaseModule, BaseDF, ABC):
         super().__init__(dataframe)
         self.index_name = " ".join(re.findall('[A-Z][^A-Z]*', self.__class__.__name__)).lower()
 
+    @abstractmethod
     def compute_alpha_diversity(self):
         """
         method that compute the alpha diversity
         """
-        return "choose index computation method"
+        pass
 
     @property
     def alpha_diversity_indexes(self):
@@ -84,8 +85,14 @@ class AlphaDiversity(BaseModule, BaseDF, ABC):
         elif mode == "violin":
             self._visualize_violin(plotting_options, show, output_file)
 
-    def visualize_groups(self, metadata_df: pd.DataFrame, group_col: str, plotting_options: dict = None,
-                         show: Optional[bool] = True, output_file: Optional[str] = False):
+    def visualize_groups(
+        self, metadata_df: pd.DataFrame, group_col: str, plotting_options: dict = None,
+        show: Optional[bool] = True, output_file: Optional[str] = False
+    ):
+        """
+        :param metadata_df: dataframe containing metadata and information to group the data
+        :param group_col: column from metadata_df used to group the data
+        """
         title = f"Distribution of <b>{self.index_name.capitalize()}</b> among samples<br><i>grouped by {group_col}"
         xlabel = f"{group_col}"
         ylabel = f"{self.index_name.capitalize()}"

--- a/moonstone/analysis/diversity/alpha.py
+++ b/moonstone/analysis/diversity/alpha.py
@@ -79,6 +79,8 @@ class AlphaDiversity(BaseModule, BaseDF, ABC):
         if mode not in ['histogram', 'violin']:
             logger.warning("%s not a available mode, set to default (histogram)", mode)
             mode = "histogram"
+        if plotting_options is None:
+            plotting_options = {}
 
         if mode == "histogram":
             self._visualize_histogram(bins_size, plotting_options, show, output_file)
@@ -107,7 +109,6 @@ class AlphaDiversity(BaseModule, BaseDF, ABC):
             yaxis_title="Alpha indexes"
         )
         fig.show()
-
 
 
 class ShannonIndex(AlphaDiversity):

--- a/moonstone/analysis/diversity/alpha.py
+++ b/moonstone/analysis/diversity/alpha.py
@@ -1,19 +1,24 @@
+import logging
+import re
 from abc import ABC
-
 from typing import Union, Optional
 
 import pandas as pd
-import re
 import skbio
+from plotly import graph_objects as go
 
 from moonstone.core.module_base import BaseModule, BaseDF
 from moonstone.plot.graphs.histogram import Histogram
+from moonstone.plot.graphs.violin import ViolinGraph
 from moonstone.utils.plot import (
     add_default_titles_to_plotting_options
 )
 
+logger = logging.getLogger(__name__)
+
 
 class AlphaDiversity(BaseModule, BaseDF, ABC):
+    ALPHA_DIVERSITY_INDEXES_NAME = "alpha_index"
 
     def __init__(self, dataframe: Union[pd.Series, pd.DataFrame]):
         """
@@ -33,31 +38,76 @@ class AlphaDiversity(BaseModule, BaseDF, ABC):
         # call compute_alpha_diversity and store into self._alpha_indexes
         if getattr(self, '_alpha_diversity_indexes', None) is None:
             self._alpha_diversity_indexes = self.compute_alpha_diversity()
+            self._alpha_diversity_indexes.name = self.ALPHA_DIVERSITY_INDEXES_NAME
         return self._alpha_diversity_indexes
 
-    def visualize(self, bins_size: Union[int, float] = 0.1, plotting_options: dict = None,
-                  show: Optional[bool] = True, output_file: Optional[str] = False):
-
-        title = self.index_name+" (alpha diversity) distribution across the samples"
+    def _visualize_histogram(self, bins_size, plotting_options, show, output_file):
+        title = self.index_name + " (alpha diversity) distribution across the samples"
         xlabel = self.index_name
         ylabel = "number of samples"
-
-        if plotting_options is None:
-            plotting_options = {'layout': {'title_text': title, 'title_x': 0.5},
-                                'xaxes': {'title_text': xlabel},
-                                'yaxes': {'title_text': ylabel}}
-        else:
-            plotting_options = add_default_titles_to_plotting_options(plotting_options,
-                                                                      title,
-                                                                      xlabel, ylabel)
-
+        plotting_options = add_default_titles_to_plotting_options(
+            plotting_options, title, xlabel, ylabel
+        )
         hist_fig = Histogram(self.alpha_diversity_indexes)
         hist_fig.plot_one_graph(
             bins_size,
             plotting_options=plotting_options,
             show=show,
             output_file=output_file,
-            )
+        )
+
+    def _visualize_violin(self, plotting_options, show, output_file):
+        title = self.index_name + " (alpha diversity) distribution across the samples"
+        xlabel = "Group"
+        ylabel = self.index_name
+        plotting_options = add_default_titles_to_plotting_options(
+            plotting_options, title, xlabel, ylabel
+        )
+        violing_fig = ViolinGraph(self.alpha_diversity_indexes)
+        violing_fig.plot_one_graph(
+            plotting_options=plotting_options,
+            show=show,
+            output_file=output_file,
+        )
+
+    def visualize(self, mode: str = 'histogram', bins_size: Union[int, float] = 0.1, plotting_options: dict = None,
+                  show: Optional[bool] = True, output_file: Optional[str] = False):
+        """
+        :param mode: how to display (histogram or violin)
+        :param bins_size: [mode histo only] size of the histo bins
+        """
+        if mode not in ['histogram', 'violin']:
+            logger.warning("%s not a available mode, set to default (histogram)", mode)
+            mode = "histogram"
+
+        if mode == "histogram":
+            self._visualize_histogram(bins_size, plotting_options, show, output_file)
+        elif mode == "violin":
+            self._visualize_violin(plotting_options, show, output_file)
+
+    def visualize_groups(self, metadata_df: pd.DataFrame, group_col: str, plotting_options: dict = None,
+                         show: Optional[bool] = True, output_file: Optional[str] = False):
+        groups = list(metadata_df[group_col].unique())
+        groups.sort()
+
+        df = pd.concat([metadata_df['MOTIF_INC'], self.alpha_diversity_indexes], axis=1).dropna()
+
+        fig = go.Figure()
+        for group in groups:
+            fig.add_trace(go.Violin(x=df['MOTIF_INC'][df['MOTIF_INC'] == group],
+                                    y=df['alpha_index'][df['MOTIF_INC'] == group],
+                                    name=str(group),
+                                    box_visible=True,
+                                    points='all',
+                                    meanline_visible=True,
+                                    text=df.index))
+        fig.update_layout(
+            title_text=f"<b>{self.index_name.capitalize()}-index</b><br><i>grouped by {group_col}",
+            xaxis_title=f"{group_col}",
+            yaxis_title="Alpha indexes"
+        )
+        fig.show()
+
 
 
 class ShannonIndex(AlphaDiversity):

--- a/moonstone/parsers/metadata.py
+++ b/moonstone/parsers/metadata.py
@@ -14,7 +14,7 @@ class MetadataParser(BaseParser):
     Parse metadata file and allows to apply transformations on them (cleaning...).
     """
 
-    def __init__(self, *args, cleaning_operations: dict = None, **kwargs):
+    def __init__(self, *args, index_col: str = 'sample', cleaning_operations: dict = None, **kwargs):
         """
         Cleaning operations are based on DataFrameCleaner object that allow to perform transformation
         operations on different columns.
@@ -23,8 +23,10 @@ class MetadataParser(BaseParser):
 
             {'col_name': [('operation1', 'operation1_options'), ('operation2', 'operation2_options')]}
 
+        :param index_col: name of the column used as dataframe index
         :param cleaning_operations: cleaning operations to apply to the input table
         """
+        self.index_col = index_col
         self.cleaning_operations = cleaning_operations
         if self.cleaning_operations is None:
             self.cleaning_operations = {}
@@ -38,7 +40,7 @@ class MetadataParser(BaseParser):
                 transf_name = transformation[0]
                 transf_options = transformation[1]
                 df_cleaner.run_transform(col_name, transf_name, transf_options)
-        return df_cleaner.df
+        return df_cleaner.df.set_index(self.index_col)
 
     def get_stats(self) -> List[Dict]:
         """

--- a/moonstone/plot/graphs/__init__.py
+++ b/moonstone/plot/graphs/__init__.py
@@ -1,0 +1,3 @@
+from .bargraph import BarGraph  # noqa
+from .histogram import Histogram  # noqa
+from .violin import ViolinGraph  # noqa

--- a/moonstone/plot/graphs/violin.py
+++ b/moonstone/plot/graphs/violin.py
@@ -27,3 +27,31 @@ class ViolinGraph(BaseGraph):
             fig = self._handle_plotting_options_plotly(fig, plotting_options)
 
         self._handle_output_plotly(fig, show, output_file)
+
+
+class GroupViolinGraph(BaseGraph):
+
+    def plot_one_graph(
+        self, data_col: str, group_col: str, plotting_options: dict = None,
+        show: bool = True, output_file: Union[bool, str] = False
+    ):
+        """
+        :param data_col: column with data to visualize
+        :param group_col: column used to group data
+        """
+        groups = list(self.data[group_col].unique())
+        groups.sort()
+        fig = go.Figure()
+        for group in groups:
+            fig.add_trace(go.Violin(x=self.data[group_col][self.data[group_col] == group],
+                                    y=self.data[data_col][self.data[group_col] == group],
+                                    name=str(group),
+                                    box_visible=True,
+                                    points='all',
+                                    meanline_visible=True,
+                                    text=self.data.index))
+
+        if plotting_options is not None:
+            fig = self._handle_plotting_options_plotly(fig, plotting_options)
+
+        self._handle_output_plotly(fig, show, output_file)

--- a/moonstone/plot/graphs/violin.py
+++ b/moonstone/plot/graphs/violin.py
@@ -1,0 +1,29 @@
+from typing import Union
+
+import plotly.graph_objects as go
+
+from moonstone.plot.graphs.base import BaseGraph
+
+
+class ViolinGraph(BaseGraph):
+
+    def plot_one_graph(
+        self, plotting_options: dict = None,
+        show: bool = True, output_file: Union[bool, str] = False
+    ):
+        fig = go.Figure(
+            [
+                go.Violin(
+                    y=self.data,
+                    points='all',
+                    meanline_visible=True,
+                    text=self.data.index,
+                    name="All"
+                )
+            ]
+        )
+
+        if plotting_options is not None:
+            fig = self._handle_plotting_options_plotly(fig, plotting_options)
+
+        self._handle_output_plotly(fig, show, output_file)

--- a/moonstone/utils/plot.py
+++ b/moonstone/utils/plot.py
@@ -24,6 +24,8 @@ def add_x_to_plotting_options(plotting_options: dict, option_cat: str, x: str, d
 
 
 def add_default_titles_to_plotting_options(plotting_options: dict, title: str, xlabel: str, ylabel: str):
+    if plotting_options is None:
+        plotting_options = {}
     plotting_options = add_x_to_plotting_options(plotting_options, 'layout', 'title_text', title)
     plotting_options = add_x_to_plotting_options(plotting_options, 'layout', 'title_x', 0.5)
     plotting_options = add_x_to_plotting_options(plotting_options, 'xaxes', 'title_text', xlabel)

--- a/tests/parsers/test_metadata.py
+++ b/tests/parsers/test_metadata.py
@@ -17,28 +17,16 @@ class TestMetadataParser(TestCase):
     def test_parse_file(self):
         expected_df = pd.DataFrame(
             {
-                'col_1': ['s1', 's2', 's3'],
                 'col_2': [13.3, 15.3, 19.1],
                 'col_3': ['M', 'F', 'M']
             }
         )
-        parser = MetadataParser(self.metadata_file)
+        expected_df.index = pd.Index(['s1', 's2', 's3'], name='col_1')
+        parser = MetadataParser(self.metadata_file, index_col='col_1')
         assert_frame_equal(parser.dataframe, expected_df)
 
     def test_get_stats_headers(self):
         expected_list = [
-            {
-                'col_name': 'col_1',
-                'col_type': 'object',
-                'python_col_type': 'str',
-                'n_values': 3,
-                'n_uniq_values': 3,
-                'values_repartition': {
-                    's1': 1,
-                    's2': 1,
-                    's3': 1
-                }
-            },
             {
                 'col_name': 'col_2',
                 'col_type': 'float64',
@@ -64,23 +52,11 @@ class TestMetadataParser(TestCase):
                 }
             }
         ]
-        parser = MetadataParser(self.metadata_file)
+        parser = MetadataParser(self.metadata_file, index_col='col_1')
         self.assertListEqual(parser.get_stats(), expected_list)
 
     def test_get_stats_no_header(self):
         expected_list = [
-            {
-                'col_name': 0,
-                'col_type': 'object',
-                'python_col_type': 'str',
-                'n_values': 3,
-                'n_uniq_values': 3,
-                'values_repartition': {
-                    's1': 1,
-                    's2': 1,
-                    's3': 1
-                }
-            },
             {
                 'col_name': 1,
                 'col_type': 'float64',
@@ -106,39 +82,39 @@ class TestMetadataParser(TestCase):
                 }
             }
         ]
-        parser = MetadataParser(self.metadata_file_no_header, no_header=True)
+        parser = MetadataParser(self.metadata_file_no_header, no_header=True, index_col=0)
         self.assertListEqual(parser.get_stats(), expected_list)
 
     def test_parse_file_force_dtype(self):
         expected_df = pd.DataFrame(
             {
-                'col_1': ['s1', 's2', 's3'],
                 'col_2': ['13.3', '15.3', '19.1'],
                 'col_3': ['M', 'F', 'M']
             }
         )
+        expected_df.index = pd.Index(['s1', 's2', 's3'], name='col_1')
         parsing_options = {
             'dtype': {
                 'col_2': 'object'
             }
         }
-        parser = MetadataParser(self.metadata_file, parsing_options=parsing_options)
+        parser = MetadataParser(self.metadata_file, parsing_options=parsing_options, index_col='col_1')
         assert_frame_equal(parser.dataframe, expected_df)
 
     def test_parse_dirty_metadata_and_clean(self):
         expected_df = pd.DataFrame(
             {
-                'sample': ['s1', 's2', 's3', 's4'],
                 'age': [29, 48, 36, 25],
             }
         )
+        expected_df.index = pd.Index(['s1', 's2', 's3', 's4'], name='sample')
         cleaning_operations = {
             'samples': [
                 ('to_slug', {}),
                 ('rename', {'new_name': 'sample'})
             ]
         }
-        parser = MetadataParser(self.metadata_file_dirty, sep=",", cleaning_operations=cleaning_operations)
+        parser = MetadataParser(self.metadata_file_dirty, sep=",", cleaning_operations=cleaning_operations, index_col='sample')
         assert_frame_equal(parser.dataframe, expected_df)
 
 
@@ -192,11 +168,11 @@ class TestYAMLBasedMetadataParser(TestCase):
     def test_parse_end_to_end(self):
         metadata_file_dirty = os.path.join(os.path.dirname(__file__), "data/metadata/dirty_metadata.tsv")
         config_file = os.path.join(os.path.dirname(__file__), "data/metadata/config.yaml")
-        parser = YAMLBasedMetadataParser(metadata_file_dirty, config_file, sep=",")
+        parser = YAMLBasedMetadataParser(metadata_file_dirty, config_file, sep=",", index_col="sample")
         expected_df = pd.DataFrame(
             {
-                'sample': ['s1', 's2', 's3', 's4'],
                 'age': ['29', '48', '36', '25'],
             }
         )
+        expected_df.index = pd.Index(['s1', 's2', 's3', 's4'], name='sample')
         pd.testing.assert_frame_equal(parser.metadata_parser.dataframe, expected_df)


### PR DESCRIPTION
## Description

This PR works on visualization of alpha indexes and give more options to visualize directly from the class.

#### Changelogs

* new features for `AlphaDiversity` class:
  * `visualize` method now has two `mode`: `histogram` or `violin`
  * `visualize_groups` method allows visualization with violin plot based on metadata grouped by a chosen column
* There is now definition of `index_col` for `MetadataParser` to define which column to use as the index for the metadata

#### Issue(s)

*Indicates which issue is related to this Pull Request*

Fixes #37

## Definition of Done

* [x]  New code is tested with unit tests
* [x]  Documentation has been updated
* [x]  Pull Request has been revised by a maintainer of the project
