### PR TITLE
Feature box plot alpha diversity

### DIFF
--- a/moonstone/analysis/diversity/alpha.py
+++ b/moonstone/analysis/diversity/alpha.py
@@ -7,6 +7,7 @@ import pandas as pd
 import skbio
 
 from moonstone.core.module_base import BaseModule, BaseDF
+from moonstone.plot.graphs.box import GroupBoxGraph, BoxGraph
 from moonstone.plot.graphs.histogram import Histogram
 from moonstone.plot.graphs.violin import GroupViolinGraph, ViolinGraph
 from moonstone.utils.plot import (
@@ -56,7 +57,7 @@ class AlphaDiversity(BaseModule, BaseDF, ABC):
             output_file=output_file,
         )
 
-    def _visualize_violin(self, plotting_options, show, output_file):
+    def _visualize_violin(self, plotting_options, show, output_file, log_scale: bool = False):
         title = self.index_name + " (alpha diversity) distribution across the samples"
         xlabel = "Group"
         ylabel = self.index_name
@@ -68,31 +69,54 @@ class AlphaDiversity(BaseModule, BaseDF, ABC):
             plotting_options=plotting_options,
             show=show,
             output_file=output_file,
+            log_scale=log_scale,
+        )
+
+    def _visualize_boxplot(self, plotting_options, show, output_file, log_scale: bool = False):
+        title = self.index_name + " (alpha diversity) distribution across the samples"
+        xlabel = "Group"
+        ylabel = self.index_name
+        plotting_options = add_default_titles_to_plotting_options(
+            plotting_options, title, xlabel, ylabel
+        )
+        violing_fig = BoxGraph(self.alpha_diversity_indexes)
+        violing_fig.plot_one_graph(
+            plotting_options=plotting_options,
+            show=show,
+            output_file=output_file,
+            log_scale=log_scale,
         )
 
     def visualize(self, mode: str = 'histogram', bins_size: Union[int, float] = 0.1, plotting_options: dict = None,
-                  show: Optional[bool] = True, output_file: Optional[str] = False):
+                  show: Optional[bool] = True, output_file: Optional[str] = False, log_scale: bool = False):
         """
         :param mode: how to display (histogram or violin)
         :param bins_size: [mode histo only] size of the histo bins
         """
-        if mode not in ['histogram', 'violin']:
+        if mode not in ['histogram', 'violin', 'boxplot']:
             logger.warning("%s not a available mode, set to default (histogram)", mode)
             mode = "histogram"
 
         if mode == "histogram":
             self._visualize_histogram(bins_size, plotting_options, show, output_file)
         elif mode == "violin":
-            self._visualize_violin(plotting_options, show, output_file)
+            self._visualize_violin(plotting_options, show, output_file, log_scale=log_scale)
+        elif mode == "boxplot":
+            self._visualize_box(plotting_options, show, output_file, log_scale=log_scale)
 
     def visualize_groups(
         self, metadata_df: pd.DataFrame, group_col: str, plotting_options: dict = None,
-        show: Optional[bool] = True, output_file: Optional[str] = False
+        show: Optional[bool] = True, output_file: Optional[str] = False,
+        log_scale: bool = False, mode: str = 'boxplot'
     ):
         """
         :param metadata_df: dataframe containing metadata and information to group the data
         :param group_col: column from metadata_df used to group the data
         """
+        if mode not in ['violin', 'boxplot']:
+            logger.warning("%s not a available mode, set to default (histogram)", mode)
+            mode = "boxplot"
+
         title = f"Distribution of <b>{self.index_name.capitalize()}</b> among samples<br><i>grouped by {group_col}"
         xlabel = f"{group_col}"
         ylabel = f"{self.index_name.capitalize()}"
@@ -101,12 +125,16 @@ class AlphaDiversity(BaseModule, BaseDF, ABC):
         )
 
         df = pd.concat([metadata_df[group_col], self.alpha_diversity_indexes], axis=1).dropna()
-        violin_fig = GroupViolinGraph(df)
-        violin_fig.plot_one_graph(
+        if mode == "violin":
+            fig = GroupViolinGraph(df)
+        elif mode == "boxplot":
+            fig = GroupBoxGraph(df)
+        fig.plot_one_graph(
             self.ALPHA_DIVERSITY_INDEXES_NAME, group_col,
             plotting_options=plotting_options,
             show=show,
             output_file=output_file,
+            log_scale=log_scale,
         )
 
 

--- a/moonstone/analysis/diversity/alpha.py
+++ b/moonstone/analysis/diversity/alpha.py
@@ -102,7 +102,7 @@ class AlphaDiversity(BaseModule, BaseDF, ABC):
         elif mode == "violin":
             self._visualize_violin(plotting_options, show, output_file, log_scale=log_scale)
         elif mode == "boxplot":
-            self._visualize_box(plotting_options, show, output_file, log_scale=log_scale)
+            self._visualize_boxplot(plotting_options, show, output_file, log_scale=log_scale)
 
     def visualize_groups(
         self, metadata_df: pd.DataFrame, group_col: str, plotting_options: dict = None,

--- a/moonstone/analysis/diversity/alpha.py
+++ b/moonstone/analysis/diversity/alpha.py
@@ -108,6 +108,7 @@ class AlphaDiversity(BaseModule, BaseDF, ABC):
         self, metadata_df: pd.DataFrame, group_col: str, plotting_options: dict = None,
         show: Optional[bool] = True, output_file: Optional[str] = False,
         log_scale: bool = False, mode: str = 'boxplot', colors: dict = None,
+        groups: list = None
     ):
         """
         :param metadata_df: dataframe containing metadata and information to group the data
@@ -136,6 +137,7 @@ class AlphaDiversity(BaseModule, BaseDF, ABC):
             output_file=output_file,
             log_scale=log_scale,
             colors=colors,
+            groups=groups,
         )
 
 

--- a/moonstone/analysis/diversity/alpha.py
+++ b/moonstone/analysis/diversity/alpha.py
@@ -96,11 +96,16 @@ class AlphaDiversity(BaseModule, BaseDF, ABC):
             output_file=output_file,
         )
 
-    def visualize(self, mode: str = 'histogram', bins_size: Union[int, float] = 0.1, plotting_options: dict = None,
-                  show: Optional[bool] = True, output_file: Optional[str] = False, log_scale: bool = False):
+    def visualize(
+        self, mode: str = 'histogram', bins_size: Union[int, float] = 0.1, log_scale: bool = False,
+        show: bool = True, output_file: str = False, plotting_options: dict = None,
+    ):
         """
-        :param mode: how to display (histogram or violin)
+        :param mode: how to display (histogram, boxplot, or violin)
         :param bins_size: [mode histo only] size of the histo bins
+        :param show: display your graph
+        :param output_file: file path to output your html graph
+        :param plotting_options: plotly plotting_options
         """
         if mode not in ['histogram', 'violin', 'boxplot']:
             logger.warning("%s not a available mode, set to default (histogram)", mode)
@@ -114,14 +119,20 @@ class AlphaDiversity(BaseModule, BaseDF, ABC):
             self._visualize_boxplot(plotting_options, show, output_file, log_scale)
 
     def visualize_groups(
-        self, metadata_df: pd.DataFrame, group_col: str, plotting_options: dict = None,
-        show: Optional[bool] = True, output_file: Optional[str] = False,
-        log_scale: bool = False, mode: str = 'boxplot', colors: dict = None,
-        groups: list = None
+        self, metadata_df: pd.DataFrame, group_col: str,  mode: str = 'boxplot',
+        log_scale: bool = False, colors: dict = None, groups: list = None,
+        show: bool = True, output_file: str = False,
+        plotting_options: dict = None,
     ):
         """
         :param metadata_df: dataframe containing metadata and information to group the data
         :param group_col: column from metadata_df used to group the data
+        :param mode: how to display (boxplot, or violin)
+        :param colors: overides color for groups. format {group_id: color}
+        :param groups: specifically select groups to display among group_col
+        :param show: display your graph
+        :param output_file: file path to output your html graph
+        :param plotting_options: plotly plotting_options
         """
         if mode not in ['violin', 'boxplot']:
             logger.warning("%s not a available mode, set to default (histogram)", mode)

--- a/moonstone/analysis/diversity/alpha.py
+++ b/moonstone/analysis/diversity/alpha.py
@@ -107,7 +107,7 @@ class AlphaDiversity(BaseModule, BaseDF, ABC):
     def visualize_groups(
         self, metadata_df: pd.DataFrame, group_col: str, plotting_options: dict = None,
         show: Optional[bool] = True, output_file: Optional[str] = False,
-        log_scale: bool = False, mode: str = 'boxplot'
+        log_scale: bool = False, mode: str = 'boxplot', colors: dict = None,
     ):
         """
         :param metadata_df: dataframe containing metadata and information to group the data
@@ -135,6 +135,7 @@ class AlphaDiversity(BaseModule, BaseDF, ABC):
             show=show,
             output_file=output_file,
             log_scale=log_scale,
+            colors=colors,
         )
 
 

--- a/moonstone/plot/graphs/__init__.py
+++ b/moonstone/plot/graphs/__init__.py
@@ -1,3 +1,4 @@
 from .bargraph import BarGraph  # noqa
+from .box import BoxGraph  # noqa
 from .histogram import Histogram  # noqa
 from .violin import ViolinGraph  # noqa

--- a/moonstone/plot/graphs/base.py
+++ b/moonstone/plot/graphs/base.py
@@ -118,10 +118,10 @@ class GroupBaseGraph(BaseGraph):
         fig = go.Figure()
 
         for group in groups:
+            filtered_df = self.data[self.data[group_col] == group]
             fig.add_trace(self._gen_fig_trace(
-                self.data[group_col][self.data[group_col] == group],
-                self.data[data_col][self.data[group_col] == group],
-                str(group), self.data.index, self._get_group_color(group, colors)
+                filtered_df[group_col], filtered_df[data_col],
+                str(group), filtered_df.index, self._get_group_color(group, colors)
             ))
 
         if plotting_options is not None:

--- a/moonstone/plot/graphs/base.py
+++ b/moonstone/plot/graphs/base.py
@@ -66,7 +66,7 @@ class BaseGraph(ABC):
 
     def _handle_output_plotly(self, fig, show: bool, output_file: str, log_scale: bool = False):
         if log_scale:
-            fig.update_yaxes(type="log")
+            fig.update_yaxes(type="log", title=f"{fig.layout.yaxis.title.text} (log)")
 
         if show is True:
             fig.show()
@@ -105,14 +105,17 @@ class GroupBaseGraph(BaseGraph):
     def plot_one_graph(
         self, data_col: str, group_col: str, plotting_options: dict = None,
         show: bool = True, output_file: Union[bool, str] = False,
-        log_scale: bool = False, colors: dict = None,
+        log_scale: bool = False, colors: dict = None, sort_groups: bool = False,
+        groups: list = None,
     ):
         """
         :param data_col: column with data to visualize
         :param group_col: column used to group data
         """
-        groups = list(self.data[group_col].unique())
-        groups.sort()
+        if groups is None:
+            groups = list(self.data[group_col].unique())
+        if sort_groups:
+            groups.sort()
         if colors is None:
             colors = self._gen_default_color_dict(groups)
         fig = go.Figure()

--- a/moonstone/plot/graphs/base.py
+++ b/moonstone/plot/graphs/base.py
@@ -62,7 +62,10 @@ class BaseGraph(ABC):
             getattr(fig, updater)(plotting_options[option])
         return fig
 
-    def _handle_output_plotly(self, fig, show, output_file):
+    def _handle_output_plotly(self, fig, show: bool, output_file: str, log_scale: bool = False):
+        if log_scale:
+            fig.update_yaxes(type="log")
+
         if show is True:
             fig.show()
 

--- a/moonstone/plot/graphs/base.py
+++ b/moonstone/plot/graphs/base.py
@@ -64,10 +64,7 @@ class BaseGraph(ABC):
             getattr(fig, updater)(plotting_options[option])
         return fig
 
-    def _handle_output_plotly(self, fig, show: bool, output_file: str, log_scale: bool = False):
-        if log_scale:
-            fig.update_yaxes(type="log", title=f"{fig.layout.yaxis.title.text} (log)")
-
+    def _handle_output_plotly(self, fig, show: bool, output_file: str):
         if show is True:
             fig.show()
 
@@ -105,8 +102,7 @@ class GroupBaseGraph(BaseGraph):
     def plot_one_graph(
         self, data_col: str, group_col: str, plotting_options: dict = None,
         show: bool = True, output_file: Union[bool, str] = False,
-        log_scale: bool = False, colors: dict = None, sort_groups: bool = False,
-        groups: list = None,
+        colors: dict = None, sort_groups: bool = False, groups: list = None,
     ):
         """
         :param data_col: column with data to visualize
@@ -130,4 +126,4 @@ class GroupBaseGraph(BaseGraph):
         if plotting_options is not None:
             fig = self._handle_plotting_options_plotly(fig, plotting_options)
 
-        self._handle_output_plotly(fig, show, output_file, log_scale)
+        self._handle_output_plotly(fig, show, output_file)

--- a/moonstone/plot/graphs/box.py
+++ b/moonstone/plot/graphs/box.py
@@ -10,7 +10,6 @@ class BoxGraph(BaseGraph):
     def plot_one_graph(
         self, plotting_options: dict = None,
         show: bool = True, output_file: Union[bool, str] = False,
-        log_scale: bool = False
     ):
         fig = go.Figure(
             [
@@ -27,7 +26,7 @@ class BoxGraph(BaseGraph):
         if plotting_options is not None:
             fig = self._handle_plotting_options_plotly(fig, plotting_options)
 
-        self._handle_output_plotly(fig, show, output_file, log_scale)
+        self._handle_output_plotly(fig, show, output_file)
 
 
 class GroupBoxGraph(GroupBaseGraph):

--- a/moonstone/plot/graphs/box.py
+++ b/moonstone/plot/graphs/box.py
@@ -2,7 +2,7 @@ from typing import Union
 
 import plotly.graph_objects as go
 
-from moonstone.plot.graphs.base import BaseGraph
+from moonstone.plot.graphs.base import BaseGraph, GroupBaseGraph
 
 
 class BoxGraph(BaseGraph):
@@ -18,7 +18,8 @@ class BoxGraph(BaseGraph):
                     y=self.data,
                     boxpoints='all',
                     text=self.data.index,
-                    name="All"
+                    name="All",
+                    marker_color=self.DEFAULT_COLOR,
                 )
             ]
         )
@@ -29,28 +30,14 @@ class BoxGraph(BaseGraph):
         self._handle_output_plotly(fig, show, output_file, log_scale)
 
 
-class GroupBoxGraph(BaseGraph):
+class GroupBoxGraph(GroupBaseGraph):
 
-    def plot_one_graph(
-        self, data_col: str, group_col: str, plotting_options: dict = None,
-        show: bool = True, output_file: Union[bool, str] = False,
-        log_scale: bool = False
-    ):
-        """
-        :param data_col: column with data to visualize
-        :param group_col: column used to group data
-        """
-        groups = list(self.data[group_col].unique())
-        groups.sort()
-        fig = go.Figure()
-        for group in groups:
-            fig.add_trace(go.Box(x=self.data[group_col][self.data[group_col] == group],
-                                 y=self.data[data_col][self.data[group_col] == group],
-                                 name=str(group),
-                                 boxpoints='all',
-                                 text=self.data.index))
-
-        if plotting_options is not None:
-            fig = self._handle_plotting_options_plotly(fig, plotting_options)
-
-        self._handle_output_plotly(fig, show, output_file, log_scale)
+    def _gen_fig_trace(self, x: list, y: list, name: str, text: list, color: str):
+        return go.Box(
+            x=x,
+            y=y,
+            name=name,
+            text=text,
+            marker_color=color,
+            boxpoints='all',
+        )

--- a/moonstone/plot/graphs/box.py
+++ b/moonstone/plot/graphs/box.py
@@ -5,7 +5,7 @@ import plotly.graph_objects as go
 from moonstone.plot.graphs.base import BaseGraph
 
 
-class ViolinGraph(BaseGraph):
+class BoxGraph(BaseGraph):
 
     def plot_one_graph(
         self, plotting_options: dict = None,
@@ -14,20 +14,22 @@ class ViolinGraph(BaseGraph):
     ):
         fig = go.Figure(
             [
-                go.Violin(
+                go.Box(
                     y=self.data,
-                    points='all',
-                    meanline_visible=True,
+                    boxpoints='all',
                     text=self.data.index,
                     name="All"
                 )
             ]
         )
 
+        if plotting_options is not None:
+            fig = self._handle_plotting_options_plotly(fig, plotting_options)
+
         self._handle_output_plotly(fig, show, output_file, log_scale)
 
 
-class GroupViolinGraph(BaseGraph):
+class GroupBoxGraph(BaseGraph):
 
     def plot_one_graph(
         self, data_col: str, group_col: str, plotting_options: dict = None,
@@ -42,12 +44,13 @@ class GroupViolinGraph(BaseGraph):
         groups.sort()
         fig = go.Figure()
         for group in groups:
-            fig.add_trace(go.Violin(x=self.data[group_col][self.data[group_col] == group],
-                                    y=self.data[data_col][self.data[group_col] == group],
-                                    name=str(group),
-                                    box_visible=True,
-                                    points='all',
-                                    meanline_visible=True,
-                                    text=self.data.index))
+            fig.add_trace(go.Box(x=self.data[group_col][self.data[group_col] == group],
+                                 y=self.data[data_col][self.data[group_col] == group],
+                                 name=str(group),
+                                 boxpoints='all',
+                                 text=self.data.index))
+
+        if plotting_options is not None:
+            fig = self._handle_plotting_options_plotly(fig, plotting_options)
 
         self._handle_output_plotly(fig, show, output_file, log_scale)

--- a/moonstone/plot/graphs/violin.py
+++ b/moonstone/plot/graphs/violin.py
@@ -10,7 +10,6 @@ class ViolinGraph(BaseGraph):
     def plot_one_graph(
         self, plotting_options: dict = None,
         show: bool = True, output_file: Union[bool, str] = False,
-        log_scale: bool = False
     ):
         fig = go.Figure(
             [
@@ -24,7 +23,10 @@ class ViolinGraph(BaseGraph):
             ]
         )
 
-        self._handle_output_plotly(fig, show, output_file, log_scale)
+        if plotting_options is not None:
+            fig = self._handle_plotting_options_plotly(fig, plotting_options)
+
+        self._handle_output_plotly(fig, show, output_file)
 
 
 class GroupViolinGraph(GroupBaseGraph):

--- a/moonstone/plot/graphs/violin.py
+++ b/moonstone/plot/graphs/violin.py
@@ -2,7 +2,7 @@ from typing import Union
 
 import plotly.graph_objects as go
 
-from moonstone.plot.graphs.base import BaseGraph
+from moonstone.plot.graphs.base import BaseGraph, GroupBaseGraph
 
 
 class ViolinGraph(BaseGraph):
@@ -27,27 +27,16 @@ class ViolinGraph(BaseGraph):
         self._handle_output_plotly(fig, show, output_file, log_scale)
 
 
-class GroupViolinGraph(BaseGraph):
+class GroupViolinGraph(GroupBaseGraph):
 
-    def plot_one_graph(
-        self, data_col: str, group_col: str, plotting_options: dict = None,
-        show: bool = True, output_file: Union[bool, str] = False,
-        log_scale: bool = False
-    ):
-        """
-        :param data_col: column with data to visualize
-        :param group_col: column used to group data
-        """
-        groups = list(self.data[group_col].unique())
-        groups.sort()
-        fig = go.Figure()
-        for group in groups:
-            fig.add_trace(go.Violin(x=self.data[group_col][self.data[group_col] == group],
-                                    y=self.data[data_col][self.data[group_col] == group],
-                                    name=str(group),
-                                    box_visible=True,
-                                    points='all',
-                                    meanline_visible=True,
-                                    text=self.data.index))
-
-        self._handle_output_plotly(fig, show, output_file, log_scale)
+    def _gen_fig_trace(self, x: list, y: list, name: str, text: list, color: str):
+        return go.Violin(
+            x=x,
+            y=y,
+            name=name,
+            text=text,
+            line_color=color,
+            box_visible=True,
+            points='all',
+            meanline_visible=True,
+        )


### PR DESCRIPTION
## Description

Following the work on Mitica project, I have added options to customize the plots and change default colors and added boxplots.

#### Changelogs

* Add `BoxGraph` class that builds boxplots.
* Add option to display `AlphaDiversity` indexes with boxplots
* Add options to `BoxGraph` and `ViolinGraph`:
  * change colors: give a dict of group_id and color_code
  * force groups: give an ordered list of the group you wish to display
  * add log scale option

## Definition of Done

* [ ]  Documentation has been updated
* [ ]  Pull Request has been revised by a maintainer of the project
