### PR TITLE
add HeatmapGraph

### DIFF
--- a/moonstone/analysis/diversity/base.py
+++ b/moonstone/analysis/diversity/base.py
@@ -156,19 +156,24 @@ class DiversityBase(BaseModule, BaseDF, ABC):
             **kwargs
         )
 
-    def _visualize_pvalue_matrix(self, pval: pd.DataFrame):
+    def _visualize_pvalue_matrix(self, pval: pd.DataFrame, output_pval_file: str):
         graph = HeatmapGraph(pval)
         plotting_options = {
             'layout': {
                 'title': 'Heatmap visualization of p-values',
             }
         }
-        graph.plot_one_graph(colorscale=self.DEF_PVAL_COLORSCALE, plotting_options=plotting_options)
+        graph.plot_one_graph(
+            colorscale=self.DEF_PVAL_COLORSCALE,
+            plotting_options=plotting_options,
+            output_file=output_pval_file
+        )
 
     def analyse_groups(
         self, metadata_df: pd.DataFrame, group_col: str,  mode: str = 'boxplot',
         log_scale: bool = False, colors: dict = None, groups: list = None,
-        show: bool = True, show_pval: bool = True, output_file: str = False, make_graph: bool = True,
+        show: bool = True, output_file: str = False, make_graph: bool = True,
+        show_pval: bool = True, output_pval_file: str = False,
         stats_test: str = "mann_whitney_u", plotting_options: dict = None, **kwargs
     ) -> dict:
         """
@@ -195,7 +200,7 @@ class DiversityBase(BaseModule, BaseDF, ABC):
                 colors, groups, **kwargs
             )
             if show_pval:
-                self._visualize_pvalue_matrix(pval)
+                self._visualize_pvalue_matrix(pval, output_pval_file)
 
         self.last_grouped_df = df
         return {

--- a/moonstone/plot/graphs/__init__.py
+++ b/moonstone/plot/graphs/__init__.py
@@ -1,5 +1,6 @@
 from .bargraph import BarGraph  # noqa
 from .box import BoxGraph, GroupBoxGraph  # noqa
+from .heatmap import HeatmapGraph  # noqa
 from .histogram import Histogram  # noqa
 from .scatter import (  # noqa
     ScatterGraph, GroupScatterGraph,

--- a/moonstone/plot/graphs/heatmap.py
+++ b/moonstone/plot/graphs/heatmap.py
@@ -1,0 +1,30 @@
+from typing import Union, List
+
+import plotly.graph_objects as go
+
+from .base import BaseGraph
+
+
+class HeatmapGraph(BaseGraph):
+
+    def plot_one_graph(
+        self, plotting_options: dict = None,
+        show: bool = True, output_file: Union[bool, str] = False,
+        colorscale: List[list] = None,
+    ):
+        fig = go.Figure(
+            [
+                go.Heatmap(
+                    x=self.data.columns,
+                    y=self.data.index,
+                    z=self.data,
+                    text=self.data,
+                    colorscale=colorscale,
+                )
+            ]
+        )
+
+        if plotting_options is not None:
+            fig = self._handle_plotting_options_plotly(fig, plotting_options)
+
+        self._handle_output_plotly(fig, show, output_file)

--- a/tests/analysis/diversity/test_beta.py
+++ b/tests/analysis/diversity/test_beta.py
@@ -75,7 +75,7 @@ class TestBrayCurtis(TestCase):
             },
             orient='index', columns=['beta_index', 'sex']
         )
-        output = tested_object_instance.analyse_groups(metadata_df, 'sex', show=False)
+        output = tested_object_instance.analyse_groups(metadata_df, 'sex', show=False, show_pval=False)
         pd.testing.assert_frame_equal(
             output['data'], expected_object,
             check_less_precise=2,  # Deprecated since version 1.1.0, to be changed when updating pandas


### PR DESCRIPTION
## Description

Add support for heatmap and use it for visualization of diversity p-values.

#### Changelogs

* add `HeatmapGraph` to support heatmap visualization (`plot.graphs.heatmap`)
* use heatmap visualization when analyzing groups in diversity. Can choose to visualize or not with `show_pval` option.

#### Issue(s)

Fixes #55 

## Definition of Done

* [ ]  New code is tested with unit tests
* [ ]  Documentation has been updated
* [x]  Pull Request has been revised by a maintainer of the project
