### PR TITLE
Visualize metadata cat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ output
 
 # readthedocs
 _build/
+stubs/
 
 # local notebooks
 notebooks/

--- a/docs/api_docs/analysis.rst
+++ b/docs/api_docs/analysis.rst
@@ -7,27 +7,22 @@ Analysis
 Differential Analysis
 =====================
 
-.. automodule:: moonstone.analysis.differential_analysis
-    :members:
-    :undoc-members:
-    :special-members: __init__
-    :inherited-members:
+.. currentmodule:: moonstone.analysis.differential_analysis
+
+.. autosummary::
+    :toctree: stubs
+
+    DifferentialAnalysis
 
 
-Alpha diversity
-===============
+Diversity
+=========
 
-.. automodule:: moonstone.analysis.diversity.alpha
-    :members:
-    :undoc-members:
-    :special-members: __init__
-    :inherited-members:
+.. currentmodule:: moonstone.analysis.diversity
 
-Beta diversity
-==============
+.. autosummary::
+    :toctree: stubs
 
-.. automodule:: moonstone.analysis.diversity.beta
-    :members:
-    :undoc-members:
-    :special-members: __init__
-    :inherited-members:
+    alpha.ShannonIndex
+    alpha.SimpsonInverseIndex
+    beta.BrayCurtis

--- a/docs/api_docs/parsers.rst
+++ b/docs/api_docs/parsers.rst
@@ -4,56 +4,52 @@
 Parsers
 *******
 
+How it works?
+=============
+
+.. code-block:: python
+
+    from moonstone.parsers import YourFavouriteParser
+
+    parser = YourFavouriteParser("/path/to/the/file")
+    df = parser.dataframe
+
+---------
+
 Counts
 ======
 
 Simple Counts
 """""""""""""
 
-.. automodule:: moonstone.parsers.counts.genes
-    :members:
-    :undoc-members:
-    :special-members: __init__
-    :inherited-members:
+.. currentmodule:: moonstone.parsers.counts
 
-.. automodule:: moonstone.parsers.counts.picrust2
-    :members:
-    :undoc-members:
-    :special-members: __init__
-    :inherited-members:
+.. autosummary::
+    :toctree: stubs
+
+    GeneCountsParser
+    Picrust2PathwaysParser
 
 Taxonomy Counts
 """""""""""""""
 
-.. automodule:: moonstone.parsers.counts.taxonomy.kraken2
-    :members:
-    :undoc-members:
-    :special-members: __init__
-    :inherited-members:
+.. currentmodule:: moonstone.parsers.counts.taxonomy
 
-.. automodule:: moonstone.parsers.counts.taxonomy.metaphlan2
-    :members:
-    :undoc-members:
-    :special-members: __init__
-    :inherited-members:
+.. autosummary::
+    :toctree: stubs
 
-.. automodule:: moonstone.parsers.counts.taxonomy.metaphlan3
-    :members:
-    :undoc-members:
-    :special-members: __init__
-    :inherited-members:
-
-.. automodule:: moonstone.parsers.counts.taxonomy.qiime
-    :members:
-    :undoc-members:
-    :special-members: __init__
-    :inherited-members:
+    SunbeamKraken2Parser
+    Metaphlan2Parser
+    Metaphlan3Parser
+    Qiime2Parser
 
 Metadata
 ========
 
-.. autoclass:: moonstone.parsers.metadata.MetadataParser
-    :members:
-    :undoc-members:
-    :special-members: __init__
-    :inherited-members:
+.. currentmodule:: moonstone.parsers.metadata
+
+.. autosummary::
+    :toctree: stubs
+
+    MetadataParser
+    YAMLBasedMetadataParser

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,8 +32,10 @@ author = u'Kenzo-Hugo Hillion, Agnès Baud, Mariela Furstenheim, Sean Kennedy'
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.autosummary',
+    'sphinx.ext.napoleon',
     'sphinx_autodoc_typehints',
-    'sphinx.ext.autosummary'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -44,6 +46,7 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
+autosummary_generate = True
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/moonstone/analysis/statistical_test.py
+++ b/moonstone/analysis/statistical_test.py
@@ -6,11 +6,14 @@ from typing import List, Union
 from moonstone.utils.pandas.series import SeriesBinning
 
 import logging
+
 logger = logging.getLogger(__name__)
 DEFAULT_STATS_TEST = "mann_whitney_u"
 
 
-def _preprocess_groups_comparison(series: pd.Series, group_series: pd.Series, stat_test: str):
+def _preprocess_groups_comparison(
+    series: pd.Series, group_series: pd.Series, stat_test: str
+):
     groups = list(group_series.unique())
     groups.sort()
 
@@ -18,12 +21,14 @@ def _preprocess_groups_comparison(series: pd.Series, group_series: pd.Series, st
     new_groups = []
     for i in groups:
         groupi = series[group_series[group_series == i].index].dropna()
-        if groupi.size < 20 and stat_test == 'mann_whitney_u':
-            logger.warning(f'Less than 20 observations for group {i} in data.')
+        if groupi.size < 20 and stat_test == "mann_whitney_u":
+            logger.warning(f"Less than 20 observations for group {i} in data.")
             list_of_series += [groupi]
             new_groups += [i]
-        elif groupi.size < 10 and stat_test == 'chi2_contingency':
-            logger.warning(f'Not enough observations (<10) for group {i} in data. Group dropped.')
+        elif groupi.size < 10 and stat_test == "chi2_contingency":
+            logger.warning(
+                f"Not enough observations (<10) for group {i} in data. Group dropped."
+            )
         else:
             list_of_series += [groupi]
             new_groups += [i]
@@ -34,8 +39,14 @@ def _preprocess_groups_comparison(series: pd.Series, group_series: pd.Series, st
     return new_groups, list_of_series
 
 
-def statistical_test_groups_comparison(series: pd.Series, group_series: pd.Series, stat_test: str,
-                                       output: str = 'dataframe', sym: str = True, **kwargs):
+def statistical_test_groups_comparison(
+    series: pd.Series,
+    group_series: pd.Series,
+    stat_test: str,
+    output: str = "dataframe",
+    sym: str = True,
+    **kwargs,
+):
     """
     :param output: {'series', 'dataframe'}
     :param sym: whether generated dataframe (or MultiIndexed series) is symetric or half-full
@@ -48,48 +59,66 @@ def statistical_test_groups_comparison(series: pd.Series, group_series: pd.Serie
     :param bins: For chi2_contingency, you can define bins.
     """
 
-    method = ['mann_whitney_u', 'ttest_independence', 'chi2_contingency']
+    method = ["mann_whitney_u", "ttest_independence", "chi2_contingency"]
     if stat_test not in method:
-        logger.warning("%s not a available mode, set to default (%s)", stat_test, DEFAULT_STATS_TEST)
+        logger.warning(
+            "%s not a available mode, set to default (%s)",
+            stat_test,
+            DEFAULT_STATS_TEST,
+        )
         stat_test = DEFAULT_STATS_TEST
         # raise NotImplementedError("Method %s not implemented" % stat_test)
 
     # split dataframe by group + warn and/or drop groups not respecting minimum number of observations
-    groups, list_of_series = _preprocess_groups_comparison(series, group_series, stat_test)
+    groups, list_of_series = _preprocess_groups_comparison(
+        series, group_series, stat_test
+    )
 
     # if no bins defined, compute automatically bins that will be used to bin every series of group
-    if stat_test == 'chi2_contingency' and 'bins' not in kwargs.keys():
-        kwargs['bins'] = _compute_best_bins_values(list_of_series)
+    if stat_test == "chi2_contingency" and "bins" not in kwargs.keys():
+        kwargs["bins"] = _compute_best_bins_values(list_of_series)
 
-    if output == 'series':
+    if output == "series":
         dic_df = {}
         for i in range(len(groups)):
-            for j in range(i+1, len(groups)):
+            for j in range(i + 1, len(groups)):
 
-                if stat_test == 'mann_whitney_u':
-                    pval = mann_whitney_u(list_of_series[i], list_of_series[j], **kwargs)[1]
-                elif stat_test == 'ttest_independence':
-                    pval = ttest_independence(list_of_series[i], list_of_series[j], **kwargs)[1]
-                if stat_test == 'chi2_contingency':
-                    pval = chi2_contingency(list_of_series[i], list_of_series[j], **kwargs)[1]
+                if stat_test == "mann_whitney_u":
+                    pval = mann_whitney_u(
+                        list_of_series[i], list_of_series[j], **kwargs
+                    )[1]
+                elif stat_test == "ttest_independence":
+                    pval = ttest_independence(
+                        list_of_series[i], list_of_series[j], **kwargs
+                    )[1]
+                if stat_test == "chi2_contingency":
+                    pval = chi2_contingency(
+                        list_of_series[i], list_of_series[j], **kwargs
+                    )[1]
 
                 dic_df[(groups[i], groups[j])] = pval
                 if sym:
                     dic_df[(groups[j], groups[i])] = pval
         pvalue_df = pd.Series(dic_df)
-        pvalue_df.index = pd.MultiIndex.from_tuples(pvalue_df.index, names=['Group', 'Group'])
+        pvalue_df.index = pd.MultiIndex.from_tuples(
+            pvalue_df.index, names=["Group", "Group"]
+        )
         return pvalue_df
 
     tab = [[np.nan] * len(groups) for _ in range(len(groups))]
     for i in range(len(groups)):
-        for j in range(i+1, len(groups)):
+        for j in range(i + 1, len(groups)):
 
-            if stat_test == 'mann_whitney_u':
+            if stat_test == "mann_whitney_u":
                 pval = mann_whitney_u(list_of_series[i], list_of_series[j], **kwargs)[1]
-            elif stat_test == 'ttest_independence':
-                pval = ttest_independence(list_of_series[i], list_of_series[j], **kwargs)[1]
-            if stat_test == 'chi2_contingency':
-                pval = chi2_contingency(list_of_series[i], list_of_series[j], **kwargs)[1]
+            elif stat_test == "ttest_independence":
+                pval = ttest_independence(
+                    list_of_series[i], list_of_series[j], **kwargs
+                )[1]
+            if stat_test == "chi2_contingency":
+                pval = chi2_contingency(list_of_series[i], list_of_series[j], **kwargs)[
+                    1
+                ]
 
             tab[i][j] = pval
             if sym:
@@ -97,12 +126,16 @@ def statistical_test_groups_comparison(series: pd.Series, group_series: pd.Serie
     return pd.DataFrame(tab, index=groups, columns=groups)
 
 
-def mann_whitney_u(series1: pd.Series, series2: pd.Series, alternative: str = 'two-sided', **kwargs):
+def mann_whitney_u(
+    series1: pd.Series, series2: pd.Series, alternative: str = "two-sided", **kwargs
+):
     # alternative = 'two-sided' is the default but using None gives a warning
     return stats.mannwhitneyu(series1, series2, alternative=alternative)
 
 
-def ttest_independence(series1: pd.Series, series2: pd.Series, equal_var: bool = False, **kwargs):
+def ttest_independence(
+    series1: pd.Series, series2: pd.Series, equal_var: bool = False, **kwargs
+):
     # equal_var = False is Welch's t-test
     return stats.ttest_ind(series1, series2, equal_var=equal_var)
 
@@ -112,7 +145,7 @@ def _compute_best_bins_values(list_of_series):
     max = -float("inf")
     min = float("inf")
     for series in list_of_series:
-        tmp = int(series.size/5)      # maybe add other criterium to lower the max_cat
+        tmp = int(series.size / 5)  # maybe add other criterium to lower the max_cat
         if tmp < max_cat:
             max_cat = tmp
         tmp = series.min()
@@ -130,7 +163,10 @@ def _compute_best_bins_values(list_of_series):
         if bins is not None:
             s_binning = SeriesBinning(series)
             s_binning.bins_values = bins
-            if s_binning.binned_data[s_binning.binned_data >= 5].size == s_binning.binned_data.size:
+            if (
+                s_binning.binned_data[s_binning.binned_data >= 5].size
+                == s_binning.binned_data.size
+            ):
                 ind_validated += [ind]
                 ind += 1
                 continue
@@ -138,22 +174,38 @@ def _compute_best_bins_values(list_of_series):
             nb_cat -= 1
         while nb_cat > 1:
             s_binning = SeriesBinning(series)
-            bins_values = s_binning.compute_homogeneous_bins(min=min, max=max, nb_bins=nb_cat)
+            bins_values = s_binning.compute_homogeneous_bins(
+                min=min, max=max, nb_bins=nb_cat
+            )
             s_binning.bins_values = bins_values
-            if s_binning.binned_data[s_binning.binned_data >= 5].size == s_binning.binned_data.size:
-                bins = s_binning.bins_values                              # since bins_values has changed, we need ...
-                list_of_series += [list_of_series[i] for i in ind_validated]  # to check new bins with previous series
+            if (
+                s_binning.binned_data[s_binning.binned_data >= 5].size
+                == s_binning.binned_data.size
+            ):
+                bins = (
+                    s_binning.bins_values
+                )  # since bins_values has changed, we need ...
+                list_of_series += [
+                    list_of_series[i] for i in ind_validated
+                ]  # to check new bins with previous series
                 ind_validated = [ind]
                 break
             nb_cat -= 1
         if nb_cat < 1:
-            raise RuntimeError("moonstone wasn't able to compute a contingency table of at least 2 x 2 with the data.")
+            raise RuntimeError(
+                "moonstone wasn't able to compute a contingency table of at least 2 x 2 with the data."
+            )
         ind += 1
     return s_binning.bins_values
 
 
-def chi2_contingency(series1: pd.Series, series2: pd.Series, retbins: bool = False,
-                     bins: List[Union[int, float]] = None, **kwargs):
+def chi2_contingency(
+    series1: pd.Series,
+    series2: pd.Series,
+    retbins: bool = False,
+    bins: List[Union[int, float]] = None,
+    **kwargs,
+):
     """
     NB : Cells with 0 raise an error in the scipy.stats.chi2_contingency test. Furthermore, they recommand to use the
     test only if the observed and expected frequencies in each cell are at least 5.
@@ -161,8 +213,10 @@ def chi2_contingency(series1: pd.Series, series2: pd.Series, retbins: bool = Fal
     :param retbins: Whether to return the bins used to make the Chi2 contingency table
     """
     if series1.size < 10 or series2.size < 10:
-        logger.warning("Data have less than 10 observations by groups. \
-        Another statistical test would be more appropriate to compare the 2 groups.")
+        logger.warning(
+            "Data have less than 10 observations by groups. \
+        Another statistical test would be more appropriate to compare the 2 groups."
+        )
         return (np.nan, np.nan)
 
     if bins is None:
@@ -173,10 +227,11 @@ def chi2_contingency(series1: pd.Series, series2: pd.Series, retbins: bool = Fal
     s1_binning.bins_values = bins
     s2_binning.bins_values = bins
 
-    merged_df = pd.concat([
-        s1_binning.binned_data,
-        s2_binning.binned_data
-    ], axis=1, names=['series1', 'series2'])
+    merged_df = pd.concat(
+        [s1_binning.binned_data, s2_binning.binned_data],
+        axis=1,
+        names=["series1", "series2"],
+    )
     merged_df = merged_df.fillna(0)
     to_return = list(stats.chi2_contingency(merged_df))
     to_return += s1_binning.bins_values

--- a/moonstone/filtering/mean_filtering.py
+++ b/moonstone/filtering/mean_filtering.py
@@ -5,9 +5,7 @@ import plotly.io
 from plotly.subplots import make_subplots
 from typing import Optional
 
-from moonstone.analysis.stats import (
-    FilteringStats
-)
+from moonstone.analysis.stats import FilteringStats
 from moonstone.filtering.base import CountsFiltering
 
 logger = logging.getLogger(__name__)
@@ -20,7 +18,13 @@ class MeanFiltering(CountsFiltering):
     You can either give a mean read count threshold or the percentage of data
     that you wish to keep (the threshold will then be computed for you).
     """
-    def __init__(self, dataframe, threshold: float = None, percentage_to_keep: Optional[float] = 90):
+
+    def __init__(
+        self,
+        dataframe,
+        threshold: float = None,
+        percentage_to_keep: int = 90,
+    ):
         """
         :param threshold: mean read count threshold, when not specified the threshold
                           is therefore computed based on percentage_to_keep
@@ -39,44 +43,58 @@ class MeanFiltering(CountsFiltering):
         """
         FS_instance = FilteringStats(self.df)
         self._items_dict, self._reads_dict = FilteringStats.by_mean(FS_instance)
-        reads_dict_sort = sorted(self._reads_dict.items(), key=lambda x: x[0])  # Sorting by threshold equate to reverse
+        reads_dict_sort = sorted(
+            self._reads_dict.items(), key=lambda x: x[0]
+        )  # Sorting by threshold equate to reverse
         #                                                                        sorting by value but a little quicker
-        for i in reads_dict_sort:                                       # i[0]:threshold; i[1]:remaining number of reads
+        for i in reads_dict_sort:  # i[0]:threshold; i[1]:remaining number of reads
             if (i[1] / self.raw_reads_number) * 100 > self.percentage_to_keep:
-                threshold = float('%.1f' % i[0])
+                threshold = float("%.1f" % i[0])
                 reads = int(i[1])
-        logger.info('Computing filtering mean read count threshold...')
-        logger.info('Filtering mean read count threshold set to %.2f.' % threshold)
-        logger.info('Retaining %.1f%% of the data results in %i retained reads.'
-                    % (self.percentage_to_keep, reads))
+        logger.info("Computing filtering mean read count threshold...")
+        logger.info("Filtering mean read count threshold set to %.2f." % threshold)
+        logger.info(
+            "Retaining %.1f%% of the data results in %i retained reads."
+            % (self.percentage_to_keep, reads)
+        )
         self.threshold = threshold
         return threshold
 
     def filter(self) -> pd.DataFrame:
         if self.threshold is None:
             self.compute_threshold_best_n_percent()
-        logger.info('Filtering with threshold set to %.2f...' % self.threshold)
+        logger.info("Filtering with threshold set to %.2f..." % self.threshold)
         filtered_df = self.df
-        filtered_df.drop(filtered_df[filtered_df.mean(axis=1) < self.threshold].index, inplace=True)
+        filtered_df.drop(
+            filtered_df[filtered_df.mean(axis=1) < self.threshold].index, inplace=True
+        )
         self.remaining_items_number = filtered_df.shape[0]
         self.remaining_reads_number = filtered_df.sum().sum()
-        logger.info('Started with %i items and a total of %i reads' % (self.raw_items_number, self.raw_reads_number))
-        logger.info('Saving new matrix with %i items and %i reads' % (self.remaining_items_number,
-                                                                      self.remaining_reads_number))
-        logger.info('Retained %.2f%% of items and %.2f%% of reads' % (
-            self.remaining_items_number / self.raw_items_number * 100,
-            self.remaining_reads_number / self.raw_reads_number * 100)
+        logger.info(
+            "Started with %i items and a total of %i reads"
+            % (self.raw_items_number, self.raw_reads_number)
+        )
+        logger.info(
+            "Saving new matrix with %i items and %i reads"
+            % (self.remaining_items_number, self.remaining_reads_number)
+        )
+        logger.info(
+            "Retained %.2f%% of items and %.2f%% of reads"
+            % (
+                self.remaining_items_number / self.raw_items_number * 100,
+                self.remaining_reads_number / self.raw_reads_number * 100,
             )
+        )
         return filtered_df
 
-    def _plot_threshold_vs_remaining_data(self, html_output_file, items_name='items'):
-        '''  The x and y set below are are are either integers or floats.
-        Be aware that some operation will require an np.array  '''
+    def _plot_threshold_vs_remaining_data(self, html_output_file, items_name="items"):
+        """The x and y set below are are are either integers or floats.
+        Be aware that some operation will require an np.array"""
         x_items = list(self._items_dict.keys())  # get x values for plotting
         x_reads = list(self._reads_dict.keys())
         y_items = list(self._items_dict.values())  # get y values for plotting
         y_reads = list(self._reads_dict.values())
-        '''  The figure visualizing the data and the filtering.  '''
+        """  The figure visualizing the data and the filtering.  """
         fig = make_subplots(specs=[[{"secondary_y": True}]])  # To set a second y-axis.
         fig.add_trace(
             go.Scatter(x=x_items, y=y_items, name="Retained Items: left axis"),
@@ -87,16 +105,19 @@ class MeanFiltering(CountsFiltering):
             secondary_y=True,
         )
         fig.add_trace(
-            go.Scatter(x=[self.threshold, self.threshold],
-                       y=[0, self.raw_reads_number],
-                       mode='lines',
-                       name="90% Reads Threshold"),
+            go.Scatter(
+                x=[self.threshold, self.threshold],
+                y=[0, self.raw_reads_number],
+                mode="lines",
+                name="90% Reads Threshold",
+            ),
             secondary_y=True,
         )
         # Add figure title
         fig.update_layout(
-            title_text="Number of %s and reads in function of the threshold value" % items_name,
-            title_x=0.5
+            title_text="Number of %s and reads in function of the threshold value"
+            % items_name,
+            title_x=0.5,
         )
         # Set x-axis title
         fig.update_xaxes(title_text="threshold value")
@@ -108,13 +129,13 @@ class MeanFiltering(CountsFiltering):
         if html_output_file:
             plotly.io.write_html(fig, html_output_file)
 
-    def visualize(self, html_output_file: Optional[str] = False):
+    def visualize(self, html_output_file: str = ""):
         """
         method to visualize the filtering on the data
 
         :param html_output_file: name of the html output file
         """
-        if getattr(self, '_items_dict', None) is None:
+        if getattr(self, "_items_dict", None) is None:
             fs_instance = FilteringStats(self.df)
             self._items_dict, self._reads_dict = FilteringStats.by_mean(fs_instance)
         self._plot_threshold_vs_remaining_data(html_output_file)
@@ -126,12 +147,9 @@ class MeanFiltering(CountsFiltering):
         """
         data_dic = {
             "threshold": self.threshold,
-            "n_items_removed": self.raw_items_number-self.remaining_items_number,
-            "n_reads_removed": self.raw_reads_number-self.remaining_reads_number
-            }
-        if getattr(self, 'percentage_to_keep', None) is not None:
-            data_dic['percentage_to_keep'] = self.percentage_to_keep
-        return {
-            "title": "Filtering by mean",
-            "data": data_dic
+            "n_items_removed": self.raw_items_number - self.remaining_items_number,
+            "n_reads_removed": self.raw_reads_number - self.remaining_reads_number,
         }
+        if getattr(self, "percentage_to_keep", None) is not None:
+            data_dic["percentage_to_keep"] = self.percentage_to_keep
+        return {"title": "Filtering by mean", "data": data_dic}

--- a/moonstone/filtering/mean_filtering.py
+++ b/moonstone/filtering/mean_filtering.py
@@ -3,7 +3,7 @@ import pandas as pd
 import plotly.graph_objects as go
 import plotly.io
 from plotly.subplots import make_subplots
-from typing import Optional
+from typing import Union
 
 from moonstone.analysis.stats import FilteringStats
 from moonstone.filtering.base import CountsFiltering
@@ -23,7 +23,7 @@ class MeanFiltering(CountsFiltering):
         self,
         dataframe,
         threshold: float = None,
-        percentage_to_keep: int = 90,
+        percentage_to_keep: Union[int, float] = 90,
     ):
         """
         :param threshold: mean read count threshold, when not specified the threshold

--- a/moonstone/normalization/reads/downsize_dir.py
+++ b/moonstone/normalization/reads/downsize_dir.py
@@ -48,6 +48,7 @@ def plot_reads(file_info_dict):
         reads.append(file_info_dict[key][2])
 
     df = pd.DataFrame(index=files, data=reads, columns=['reads'])
+    return df
 
 
 class DownsizeDir:
@@ -155,4 +156,3 @@ class DownsizeDir:
         logger.info('Instantiating with parameters: %s' % wp)
         instance = DownsizePair(**wp)
         instance.downsize_pair()
-

--- a/moonstone/parsers/base.py
+++ b/moonstone/parsers/base.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 import pandas as pd
 
 
@@ -14,7 +16,7 @@ class BaseParser:
         """
         self.file_path = file_path
         self.sep = sep
-        self.header = 'infer'
+        self.header: Union[str, None] = 'infer'
         if no_header is True:
             self.header = None
         self.parsing_options = parsing_options
@@ -23,9 +25,7 @@ class BaseParser:
 
     @property
     def dataframe(self) -> pd.DataFrame:
-        """
-        retrieve the pandas dataframe constructed from the input file
-        """
+        """Retrieve the pandas dataframe constructed from the input file."""
         if getattr(self, '_dataframe', None) is None:
             self._dataframe = self.to_dataframe()
         return self._dataframe

--- a/moonstone/parsers/metadata.py
+++ b/moonstone/parsers/metadata.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from typing import Dict, List
 
 from pandas import DataFrame, Series
+import plotly.io
 import plotly.graph_objects as go
 
 from moonstone.analysis.columns_statistics import DataframeStatistics
@@ -47,7 +48,9 @@ class MetadataParser(BaseParser):
             cleaning_operations: cleaning operations to apply to the input table
         """
         self.index_col = index_col
-        self.cleaning_operations = {} if cleaning_operations is None else cleaning_operations
+        self.cleaning_operations = (
+            {} if cleaning_operations is None else cleaning_operations
+        )
         super().__init__(*args, **kwargs)
 
     def to_dataframe(self) -> DataFrame:
@@ -91,7 +94,12 @@ class MetadataParser(BaseParser):
         return self.dataframe[color_by].apply(lambda x: color_dict.get(x, 0))
 
     def visualize_categories(
-        self, categories: list, color_by: str, colorscale: list = None
+        self,
+        categories: list,
+        color_by: str,
+        colorscale: list = None,
+        title: str = "Metadata categories distribution",
+        output_file: str = "",
     ):
         """
         Visualize category metadata with parallel categories diagram.
@@ -114,7 +122,10 @@ class MetadataParser(BaseParser):
                 )
             ]
         )
+        fig.update_layout(title=title)
         fig.show()
+        if output_file:
+            plotly.io.write_html(fig, output_file)
 
 
 class YAMLBasedMetadataParser:

--- a/moonstone/parsers/metadata.py
+++ b/moonstone/parsers/metadata.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from typing import Dict, List
 
 from pandas import DataFrame
+import plotly.graph_objects as go
 
 from moonstone.analysis.columns_statistics import DataframeStatistics
 from moonstone.parsers.transform.cleaning import DataFrameCleaner
@@ -13,6 +14,15 @@ class MetadataParser(BaseParser):
     """
     Parse metadata file and allows to apply transformations on them (cleaning...).
     """
+
+    DEFAULT_COLORSCALE = [
+        [0, "rgb(166,206,227)"],
+        [0.25, "rgb(31,120,180)"],
+        [0.45, "rgb(178,223,138)"],
+        [0.65, "rgb(51,160,44)"],
+        [0.85, "rgb(251,154,153)"],
+        [1, "rgb(227,26,28)"]
+    ]
 
     def __init__(self, *args, index_col: str = 'sample', cleaning_operations: dict = None, **kwargs):
         """
@@ -47,6 +57,51 @@ class MetadataParser(BaseParser):
         :return: list of dict containing statistics about each column
         """
         return DataframeStatistics(self.dataframe).get_stats()
+
+    def _get_dimensions(self, categories):
+        dimensions = []
+        for cat in categories:
+            dimensions.append(
+                go.parcats.Dimension(
+                    values=self.dataframe[cat],
+                    categoryorder='category ascending', label=cat
+                )
+            )
+        return dimensions
+
+    def _get_color(self, color_by: str):
+        cpt = 1
+        color_dict = {}
+        for i in self.dataframe[color_by].unique():
+            color_dict[i] = cpt
+            cpt += 1
+        return self.dataframe[color_by].apply(lambda x: color_dict.get(x, 0))
+
+    def visualize_categories(self, categories: list, color_by: str, colorscale: list = None):
+        """
+        Visualize category metadata.
+
+        :param categories: list of column to display
+        :param color_by: perform coloration on the given category
+        """
+        if colorscale is None:
+            colorscale = self.DEFAULT_COLORSCALE
+        dimensions = self._get_dimensions(categories)
+        color = self._get_color(color_by)
+
+        fig = go.Figure(
+            data=[
+                go.Parcats(
+                    dimensions=dimensions,
+                    line={'color': color, 'colorscale': colorscale},
+                    hoverinfo='count',
+                    labelfont={'size': 18, 'family': 'Times'},
+                    tickfont={'size': 16, 'family': 'Times'},
+                    arrangement='freeform'
+                )
+            ]
+        )
+        fig.show()
 
 
 class YAMLBasedMetadataParser:

--- a/moonstone/parsers/metadata.py
+++ b/moonstone/parsers/metadata.py
@@ -95,8 +95,6 @@ class MetadataParser(BaseParser):
                     dimensions=dimensions,
                     line={'color': color, 'colorscale': colorscale},
                     hoverinfo='count',
-                    labelfont={'size': 18, 'family': 'Times'},
-                    tickfont={'size': 16, 'family': 'Times'},
                     arrangement='freeform'
                 )
             ]

--- a/moonstone/parsers/metadata.py
+++ b/moonstone/parsers/metadata.py
@@ -3,7 +3,7 @@ import yaml
 from collections import defaultdict
 from typing import Dict, List
 
-from pandas import DataFrame
+from pandas import DataFrame, Series
 import plotly.graph_objects as go
 
 from moonstone.analysis.columns_statistics import DataframeStatistics
@@ -70,7 +70,7 @@ class MetadataParser(BaseParser):
         """
         return DataframeStatistics(self.dataframe).get_stats()
 
-    def _get_dimensions(self, categories):
+    def _get_dimensions(self, categories) -> List[go.parcats.Dimension]:
         dimensions = []
         for cat in categories:
             dimensions.append(
@@ -82,7 +82,7 @@ class MetadataParser(BaseParser):
             )
         return dimensions
 
-    def _get_color(self, color_by: str):
+    def _get_color(self, color_by: str) -> Series:
         cpt = 1
         color_dict = {}
         for i in self.dataframe[color_by].unique():

--- a/moonstone/utils/pandas/series.py
+++ b/moonstone/utils/pandas/series.py
@@ -3,26 +3,23 @@ import numpy as np
 import pandas as pd
 from typing import Union
 
-from moonstone.utils.plot import (
-    check_list_type
-)
+from moonstone.utils.plot import check_list_type
 from moonstone.utils.convert import pandas_to_python_type
 
 
 class SeriesStatsBuilder:
-
     def __init__(self, series):
         self.series = series
 
     def _build_base_stats(self):
         repartition = self.series.value_counts()
         return {
-            'col_name': self.series.name,
-            'col_type': str(self.series.dtype),
-            'python_col_type': pandas_to_python_type(self.series.dtype),
-            'n_values': self.series.size,
-            'n_uniq_values': len(self.series.value_counts()),
-            'values_repartition': {i: repartition[i] for i in repartition.index},
+            "col_name": self.series.name,
+            "col_type": str(self.series.dtype),
+            "python_col_type": pandas_to_python_type(self.series.dtype),
+            "n_values": self.series.size,
+            "n_uniq_values": len(self.series.value_counts()),
+            "values_repartition": {i: repartition[i] for i in repartition.index},
         }
 
     def _build_object_stats(self):
@@ -30,7 +27,7 @@ class SeriesStatsBuilder:
 
     def _build_number_stats(self):
         stats_dict = self._build_base_stats()
-        stats_dict['mean'] = round(self.series.mean(), 2)
+        stats_dict["mean"] = round(self.series.mean(), 2)
         return stats_dict
 
     def _build_int64_stats(self):
@@ -40,12 +37,12 @@ class SeriesStatsBuilder:
         return self._build_number_stats()
 
     def build_stats(self):
-        return getattr(self, f"_build_{str(self.series.dtype)}_stats",
-                       self._build_base_stats)()
+        return getattr(
+            self, f"_build_{str(self.series.dtype)}_stats", self._build_base_stats
+        )()
 
 
 class SeriesBinning:
-
     def __init__(self, series: pd.Series):
         self.data = series
 
@@ -56,28 +53,32 @@ class SeriesBinning:
         bval = [-0.1, 1]  # to have the 0 value
         i = 0
         while i < magnitude:
-            bval += list(np.arange(2*10**i, 10**(i+1)+1, 10**i))
+            bval += list(np.arange(2 * 10 ** i, 10 ** (i + 1) + 1, 10 ** i))
             i += 1
         # i=magnitude
-        bval += list(np.arange(2*10**i, max+10**i, 10**i))  # up to maximum
+        bval += list(np.arange(2 * 10 ** i, max + 10 ** i, 10 ** i))  # up to maximum
         return bval
 
-    def compute_homogeneous_bins(self, min: Union[int, float] = 0, max: Union[int, float] = 'data.max()',
-                                 nb_bins: int = None):
+    def compute_homogeneous_bins(
+        self,
+        min: Union[int, float] = 0,
+        max: Union[int, float] = None,
+        nb_bins: int = None,
+    ):
         """
         :param min: lower edge of bins.
         :param max: higher edge of bins (default is the dataframe's maximum).
         :param nb_bins: number of bins.
         """
-        if max == 'data.max()':
+        if max is None:
             max = self.data.max()
         bval = [min - 0.001]  # to have the minimum value
         if nb_bins is None:
             magnitude = int(math.log10(max))
-            step = 10**magnitude
+            step = 10 ** magnitude
         else:
-            step = (max - min)/nb_bins
-        bval += list(np.arange(min+step, max+step, step))
+            step = (max - min) / nb_bins
+        bval += list(np.arange(min + step, max + step, step))
         return bval
 
     @property
@@ -85,8 +86,8 @@ class SeriesBinning:
         """
         retrieves bins_values, and compute it if no values given
         """
-        if getattr(self, '_bins_values', None) is None:
-            if getattr(self, 'heterogeneous', None):
+        if getattr(self, "_bins_values", None) is None:
+            if getattr(self, "heterogeneous", None):
                 self.bins_values = self.compute_heterogeneous_bins()
             else:
                 self.bins_values = self.compute_homogeneous_bins()
@@ -94,10 +95,14 @@ class SeriesBinning:
 
     @bins_values.setter
     def bins_values(self, bins_values):
-        if type(bins_values) == list and check_list_type(bins_values, (int, float, np.integer)):
+        if type(bins_values) == list and check_list_type(
+            bins_values, (int, float, np.integer)
+        ):
             self._bins_values = bins_values
         else:
-            raise ValueError("Error : expecting list of numerical values (int, float) in bins_values.")
+            raise ValueError(
+                "Error : expecting list of numerical values (int, float) in bins_values."
+            )
 
     def compute_binned_data(self, normalize: bool = False, heterogeneous: bool = False):
         """
@@ -105,16 +110,18 @@ class SeriesBinning:
         """
         self.heterogeneous = heterogeneous
 
-        if getattr(self, 'nb_bins', None) is not None:
+        if getattr(self, "nb_bins", None) is not None:
             binned_df, bins_values = pd.cut(self.data, bins=self.nb_bins, retbins=True)
             self.bins_values = list(bins_values)
         else:
-            binned_df = pd.cut(self.data, bins=self.bins_values)   # put every items in the appropriate bin
+            binned_df = pd.cut(
+                self.data, bins=self.bins_values
+            )  # put every items in the appropriate bin
         data = pd.value_counts(binned_df, normalize=normalize)
         data = data.reindex(binned_df.cat.categories)
         new_xnames = list(data.index.astype(str))
-        new_xnames[0] = new_xnames[0].replace('(-0.001', '[0.0')
-        new_xnames = [new_xnames[i].replace('(', ']') for i in range(len(new_xnames))]
+        new_xnames[0] = new_xnames[0].replace("(-0.001", "[0.0")
+        new_xnames = [new_xnames[i].replace("(", "]") for i in range(len(new_xnames))]
         data.index = new_xnames
         return data
 
@@ -123,6 +130,6 @@ class SeriesBinning:
         """
         :param heterogeneous: set to True, if you wish for heterogenous bins
         """
-        if getattr(self, '_binned_data', None) is None:
+        if getattr(self, "_binned_data", None) is None:
             self._binned_data = self.compute_binned_data(normalize, heterogeneous)
         return self._binned_data

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,6 @@ pytest
 pytest-cov
 jupyter
 pip-tools
+black
+pydocstyle
+mypy

--- a/tests/parsers/test_metadata.py
+++ b/tests/parsers/test_metadata.py
@@ -2,164 +2,170 @@ import os
 from unittest import TestCase
 
 import pandas as pd
+import plotly.graph_objects as go
 from pandas.testing import assert_frame_equal
 
 from moonstone.parsers.metadata import MetadataParser, YAMLBasedMetadataParser
 
 
 class TestMetadataParser(TestCase):
-
     def setUp(self):
-        self.metadata_file = os.path.join(os.path.dirname(__file__), "data/metadata/metadata.tsv")
-        self.metadata_file_no_header = os.path.join(os.path.dirname(__file__), "data/metadata/metadata_noheader.tsv")
-        self.metadata_file_dirty = os.path.join(os.path.dirname(__file__), "data/metadata/dirty_metadata.tsv")
+        self.metadata_file = os.path.join(
+            os.path.dirname(__file__), "data/metadata/metadata.tsv"
+        )
+        self.metadata_file_no_header = os.path.join(
+            os.path.dirname(__file__), "data/metadata/metadata_noheader.tsv"
+        )
+        self.metadata_file_dirty = os.path.join(
+            os.path.dirname(__file__), "data/metadata/dirty_metadata.tsv"
+        )
 
     def test_parse_file(self):
         expected_df = pd.DataFrame(
-            {
-                'col_2': [13.3, 15.3, 19.1],
-                'col_3': ['M', 'F', 'M']
-            }
+            {"col_2": [13.3, 15.3, 19.1], "col_3": ["M", "F", "M"]}
         )
-        expected_df.index = pd.Index(['s1', 's2', 's3'], name='col_1')
-        parser = MetadataParser(self.metadata_file, index_col='col_1')
+        expected_df.index = pd.Index(["s1", "s2", "s3"], name="col_1")
+        parser = MetadataParser(self.metadata_file, index_col="col_1")
         assert_frame_equal(parser.dataframe, expected_df)
 
     def test_get_stats_headers(self):
         expected_list = [
             {
-                'col_name': 'col_2',
-                'col_type': 'float64',
-                'python_col_type': 'float',
-                'n_values': 3,
-                'n_uniq_values': 3,
-                'mean': 15.9,
-                'values_repartition': {
-                    13.3: 1,
-                    15.3: 1,
-                    19.1: 1
-                }
+                "col_name": "col_2",
+                "col_type": "float64",
+                "python_col_type": "float",
+                "n_values": 3,
+                "n_uniq_values": 3,
+                "mean": 15.9,
+                "values_repartition": {13.3: 1, 15.3: 1, 19.1: 1},
             },
             {
-                'col_name': 'col_3',
-                'col_type': 'object',
-                'python_col_type': 'str',
-                'n_values': 3,
-                'n_uniq_values': 2,
-                'values_repartition': {
-                    'M': 2,
-                    'F': 1
-                }
-            }
+                "col_name": "col_3",
+                "col_type": "object",
+                "python_col_type": "str",
+                "n_values": 3,
+                "n_uniq_values": 2,
+                "values_repartition": {"M": 2, "F": 1},
+            },
         ]
-        parser = MetadataParser(self.metadata_file, index_col='col_1')
+        parser = MetadataParser(self.metadata_file, index_col="col_1")
         self.assertListEqual(parser.get_stats(), expected_list)
 
     def test_get_stats_no_header(self):
         expected_list = [
             {
-                'col_name': 1,
-                'col_type': 'float64',
-                'python_col_type': 'float',
-                'n_values': 3,
-                'n_uniq_values': 3,
-                'mean': 15.9,
-                'values_repartition': {
-                    13.3: 1,
-                    15.3: 1,
-                    19.1: 1
-                }
+                "col_name": 1,
+                "col_type": "float64",
+                "python_col_type": "float",
+                "n_values": 3,
+                "n_uniq_values": 3,
+                "mean": 15.9,
+                "values_repartition": {13.3: 1, 15.3: 1, 19.1: 1},
             },
             {
-                'col_name': 2,
-                'col_type': 'object',
-                'python_col_type': 'str',
-                'n_values': 3,
-                'n_uniq_values': 2,
-                'values_repartition': {
-                    'M': 2,
-                    'F': 1
-                }
-            }
+                "col_name": 2,
+                "col_type": "object",
+                "python_col_type": "str",
+                "n_values": 3,
+                "n_uniq_values": 2,
+                "values_repartition": {"M": 2, "F": 1},
+            },
         ]
-        parser = MetadataParser(self.metadata_file_no_header, no_header=True, index_col=0)
+        parser = MetadataParser(
+            self.metadata_file_no_header, no_header=True, index_col=0
+        )
         self.assertListEqual(parser.get_stats(), expected_list)
 
     def test_parse_file_force_dtype(self):
         expected_df = pd.DataFrame(
-            {
-                'col_2': ['13.3', '15.3', '19.1'],
-                'col_3': ['M', 'F', 'M']
-            }
+            {"col_2": ["13.3", "15.3", "19.1"], "col_3": ["M", "F", "M"]}
         )
-        expected_df.index = pd.Index(['s1', 's2', 's3'], name='col_1')
-        parsing_options = {
-            'dtype': {
-                'col_2': 'object'
-            }
-        }
-        parser = MetadataParser(self.metadata_file, parsing_options=parsing_options, index_col='col_1')
+        expected_df.index = pd.Index(["s1", "s2", "s3"], name="col_1")
+        parsing_options = {"dtype": {"col_2": "object"}}
+        parser = MetadataParser(
+            self.metadata_file, parsing_options=parsing_options, index_col="col_1"
+        )
         assert_frame_equal(parser.dataframe, expected_df)
 
     def test_parse_dirty_metadata_and_clean(self):
         expected_df = pd.DataFrame(
             {
-                'age': [29, 48, 36, 25],
+                "age": [29, 48, 36, 25],
             }
         )
-        expected_df.index = pd.Index(['s1', 's2', 's3', 's4'], name='sample')
+        expected_df.index = pd.Index(["s1", "s2", "s3", "s4"], name="sample")
         cleaning_operations = {
-            'samples': [
-                ('to_slug', {}),
-                ('rename', {'new_name': 'sample'})
-            ]
+            "samples": [("to_slug", {}), ("rename", {"new_name": "sample"})]
         }
-        parser = MetadataParser(self.metadata_file_dirty, sep=",", cleaning_operations=cleaning_operations,
-                                index_col='sample')
+        parser = MetadataParser(
+            self.metadata_file_dirty,
+            sep=",",
+            cleaning_operations=cleaning_operations,
+            index_col="sample",
+        )
         assert_frame_equal(parser.dataframe, expected_df)
+
+    def test_get_dimensions(self):
+        categories = ["col_3"]
+        parser = MetadataParser(self.metadata_file, index_col="col_1")
+        output_dimensions = parser._get_dimensions(categories)
+        self.assertEqual(len(output_dimensions), 1)
+        for dim in output_dimensions:
+            self.assertTrue(isinstance(dim, go.parcats.Dimension))
+
+    def test_get_color(self):
+        color_by = "col_3"
+        index = pd.Series(("s1", "s2", "s3"), name="col_1")
+        expected_series = pd.Series([1, 2, 1], index=index, name=color_by)
+        parser = MetadataParser(self.metadata_file, index_col="col_1")
+        pd.testing.assert_series_equal(parser._get_color(color_by), expected_series)
 
 
 class MockedYAMLBasedMetadataParser(YAMLBasedMetadataParser):
     """
     Mocked to skip __init__ and test only private methods of the class
     """
+
     def __init__(self):
         pass
 
 
 class TestYAMLBasedMetadataParser(TestCase):
-
     def setUp(self):
         # For unit tests
         self.parsing_config = [
-            {'col_name': 'col_1', 'dtype': 'object'},
-            {'col_name': 'col_2', 'operations': [{'name': 'to_slug'}]},
-            {'col_name': 'col_3', 'operations': [{'name': 'rename', 'options': {'new_name': 'new'}}]}
+            {"col_name": "col_1", "dtype": "object"},
+            {"col_name": "col_2", "operations": [{"name": "to_slug"}]},
+            {
+                "col_name": "col_3",
+                "operations": [{"name": "rename", "options": {"new_name": "new"}}],
+            },
         ]
 
     def test_extract_parsing_options(self):
-        expected_dict = {
-            'dtype': {'col_1': 'object'}
-        }
+        expected_dict = {"dtype": {"col_1": "object"}}
         parser = MockedYAMLBasedMetadataParser()
-        self.assertDictEqual(parser._extract_parsing_options(self.parsing_config), expected_dict)
+        self.assertDictEqual(
+            parser._extract_parsing_options(self.parsing_config), expected_dict
+        )
 
     def test_extract_cleaning_operations(self):
         expected_dict = {
-            'col_2': [('to_slug', {})],
-            'col_3': [('rename', {'new_name': 'new'})]
+            "col_2": [("to_slug", {})],
+            "col_3": [("rename", {"new_name": "new"})],
         }
         parser = MockedYAMLBasedMetadataParser()
-        self.assertDictEqual(parser._extract_cleaning_operations(self.parsing_config), expected_dict)
+        self.assertDictEqual(
+            parser._extract_cleaning_operations(self.parsing_config), expected_dict
+        )
 
     def test_parse_yaml_config(self):
-        config_file = os.path.join(os.path.dirname(__file__), "data/metadata/config.yaml")
-        expected_parsing_options = {
-            'dtype': {'age': 'object'}
-        }
+        config_file = os.path.join(
+            os.path.dirname(__file__), "data/metadata/config.yaml"
+        )
+        expected_parsing_options = {"dtype": {"age": "object"}}
         expected_cleaning_operations = {
-            'samples': [('to_slug', {}),
-                        ('rename', {'new_name': 'sample'})],
+            "samples": [("to_slug", {}), ("rename", {"new_name": "sample"})],
         }
         parser = MockedYAMLBasedMetadataParser()
         parser._parse_yaml_config(config_file)
@@ -167,13 +173,19 @@ class TestYAMLBasedMetadataParser(TestCase):
         self.assertDictEqual(parser.cleaning_operations, expected_cleaning_operations)
 
     def test_parse_end_to_end(self):
-        metadata_file_dirty = os.path.join(os.path.dirname(__file__), "data/metadata/dirty_metadata.tsv")
-        config_file = os.path.join(os.path.dirname(__file__), "data/metadata/config.yaml")
-        parser = YAMLBasedMetadataParser(metadata_file_dirty, config_file, sep=",", index_col="sample")
+        metadata_file_dirty = os.path.join(
+            os.path.dirname(__file__), "data/metadata/dirty_metadata.tsv"
+        )
+        config_file = os.path.join(
+            os.path.dirname(__file__), "data/metadata/config.yaml"
+        )
+        parser = YAMLBasedMetadataParser(
+            metadata_file_dirty, config_file, sep=",", index_col="sample"
+        )
         expected_df = pd.DataFrame(
             {
-                'age': ['29', '48', '36', '25'],
+                "age": ["29", "48", "36", "25"],
             }
         )
-        expected_df.index = pd.Index(['s1', 's2', 's3', 's4'], name='sample')
+        expected_df.index = pd.Index(["s1", "s2", "s3", "s4"], name="sample")
         pd.testing.assert_frame_equal(parser.metadata_parser.dataframe, expected_df)


### PR DESCRIPTION
## Description

Add visualization for categorical features of metadata with parallel category diagram.

It helps giving a quick overview of how features are distributed in your metadata.

#### Changelogs

* add `.visualize_categories` method to `MetadataParser`

## Definition of Done

* [x]  New code is tested with unit tests
* [x]  Documentation has been updated
* [ ]  Pull Request has been revised by a maintainer of the project
