### PR TITLE
Small fixes and additional options

### DIFF
--- a/moonstone/analysis/diversity/base.py
+++ b/moonstone/analysis/diversity/base.py
@@ -177,8 +177,8 @@ class DiversityBase(BaseModule, BaseDF, ABC):
                 )
 
             # dropping NaN (= comparison that couldn't have been generated due to too few samples in one or both groups)
-            corrected_pval = pd.Series(multipletests(pval.dropna(), alpha=0.05, method=correction_method)[1])   
-            
+            corrected_pval = pd.Series(multipletests(pval.dropna(), alpha=0.05, method=correction_method)[1])
+
             corrected_pval.index = pval.dropna().index   # postulate that the order hasn't changed
             if pval[pval.isnull()].size > 0:
                 corrected_pval = corrected_pval.append(pval[pval.isnull()])

--- a/moonstone/analysis/diversity/base.py
+++ b/moonstone/analysis/diversity/base.py
@@ -175,8 +175,13 @@ class DiversityBase(BaseModule, BaseDF, ABC):
                     df[self.DIVERSITY_INDEXES_NAME], df[group_col], stats_test,
                     output='series', sym=False
                 )
-            corrected_pval = pd.Series(multipletests(pval, alpha=0.05, method=correction_method)[1])
-            corrected_pval.index = pval.index   # postulate that the order hasn't changed
+
+            # dropping NaN (= comparison that couldn't have been generated due to too few samples in one or both groups)
+            corrected_pval = pd.Series(multipletests(pval.dropna(), alpha=0.05, method=correction_method)[1])   
+            
+            corrected_pval.index = pval.dropna().index   # postulate that the order hasn't changed
+            if pval[pval.isnull()].size > 0:
+                corrected_pval = corrected_pval.append(pval[pval.isnull()])
 
             # remodelling of p-values output
             corrected_pval = self._structure_remodelling(corrected_pval, structure=structure_pval, sym=sym)

--- a/moonstone/analysis/statistical_test.py
+++ b/moonstone/analysis/statistical_test.py
@@ -91,7 +91,7 @@ def statistical_test_groups_comparison(
                     pval = ttest_independence(
                         list_of_series[i], list_of_series[j], **kwargs
                     )[1]
-                if stat_test == "chi2_contingency":
+                elif stat_test == "chi2_contingency":
                     pval = chi2_contingency(
                         list_of_series[i], list_of_series[j], **kwargs
                     )[1]

--- a/moonstone/plot/graphs/base.py
+++ b/moonstone/plot/graphs/base.py
@@ -75,7 +75,10 @@ class BaseGraph(ABC):
                     output_file = self.data.name+"_"+self.__class__.__name__+".html"
                 else:
                     output_file = self.__class__.__name__+".html"
-            plotly.io.write_html(fig, output_file)
+            if output_file.split(".")[-1] == "html":
+                plotly.io.write_html(fig, output_file)
+            else:
+                plotly.io.write_image(fig, output_file)
 
 
 class GroupBaseGraph(BaseGraph):

--- a/tests/parsers/counts/taxonomy/metaphlan3/test_metaphlan3.py
+++ b/tests/parsers/counts/taxonomy/metaphlan3/test_metaphlan3.py
@@ -26,4 +26,3 @@ class TestMetaphlan2Parser(TestCase):
         )
         expected_df = expected_df.set_index(['kingdom', 'phylum', 'class', 'order', 'family', 'genus', 'species'])
         pd.testing.assert_frame_equal(self.meta2parser.dataframe, expected_df)
-


### PR DESCRIPTION
## Description

* Fixes bug that return dataframe filled with NaN after correction when there was a NaN in the pvalues because a pvalue couldn't be calculated (too few samples).
* Option to save graph in a static image format (png/jpg or jpeg/webp/svg/pdf/eps)

#### Changelogs

* Option to save graph in a static image format (png/jpg or jpeg/webp/svg/pdf/eps)

## Definition of Done

* [x]  New code is tested with unit tests
* [x]  Documentation has been updated
* [x]  Pull Request has been revised by a maintainer of the project
