### PR TITLE
106 biplot for pcoa

### DIFF
--- a/moonstone/analysis/diversity/base.py
+++ b/moonstone/analysis/diversity/base.py
@@ -400,7 +400,7 @@ class PhylogeneticDiversityBase(DiversityBase):
         if self.df.index.nlevels > 1:   # if the dataframe is a multiindex...
             self.df.groupby(self.df.index.names[-1]).sum()  # it needs to be transformed as a single index dataframe
             # otherwise error: "TypeError: not all arguments converted during string formatting"
-        if type(taxonomy_tree) == skbio.tree._tree.TreeNode:
+        if type(taxonomy_tree) is skbio.tree._tree.TreeNode:
             self.tree = taxonomy_tree
         else:
             raise RuntimeError("taxonomy_tree should be a skbio.TreeNode.")

--- a/moonstone/analysis/diversity/beta.py
+++ b/moonstone/analysis/diversity/beta.py
@@ -155,7 +155,6 @@ class BetaDiversity(DiversityBase, ABC):
             loadings: is the vector for each indiviudal variable (columns) in as many dimentions as PCs (rows).
             n: Number of individual loadings to plot.
         """
-
         pcx_pos, pcx_neg = self._map_loadings(pcx, n)
         pcy_pos, pcy_neg = self._map_loadings(pcy, n)
         map_loadings = set(pcx_pos + pcx_neg + pcy_pos + pcy_neg)

--- a/moonstone/analysis/diversity/beta.py
+++ b/moonstone/analysis/diversity/beta.py
@@ -227,14 +227,19 @@ class BetaDiversity(DiversityBase, ABC):
         return fig
 
     def visualize_pcoa(
-        self, metadata_df: pd.DataFrame, group_col: str, mode: str = 'scatter',
+        self, metadata_df: pd.DataFrame, group_col: str, group_col2: str = None,
+        mode: str = 'scatter',
         proportions: bool = False, x_pc: int = 1, y_pc: int = 2, z_pc: int = 3,
         show: bool = True, output_file: Union[bool, str] = False,
-        colors: dict = None, groups: list = None,
+        colors: dict = None, groups: list = None, groups2: list = None,
         n_biplot_features: int = 0, plotting_options: dict = None,
     ):
         """
         Args:
+            metadata_df: dataframe containing metadata and information to group the data.
+            group_col: column of the metadata_df to use for coloring.
+            group_col2: (optional) column from metadata_df to use for.
+            mode: type of graph to visualize the PCoA. { 'scatter' (default), 'scatter3d' }.
             proportions: write proportion explained for each PC in the x/y labels.
             n_biplot_features: add arrows showing the n most explanatory features per axis direction
         """
@@ -282,11 +287,13 @@ class BetaDiversity(DiversityBase, ABC):
             args_for_plot = [xvar, yvar, zvar, group_col]
         fig = graph.plot_one_graph(
             *args_for_plot,
+            group_col2=group_col2,
             plotting_options=plotting_options,
             show=tmp_show,
             output_file=tmp_output_file,
             colors=colors,
             groups=groups,
+            groups2=groups2
         )
 
         if n_biplot_features > 0:
@@ -304,7 +311,7 @@ class BetaDiversity(DiversityBase, ABC):
                 fig = self._bi_plotly(fig, pcx, pcy, d_bf.index, n_biplot_features)
 
             graph._handle_output_plotly(fig, show, output_file)
-        return fig, d_bf, self.pcoa.samples
+        return fig
 
 
 class BrayCurtis(BetaDiversity):

--- a/moonstone/analysis/diversity/beta.py
+++ b/moonstone/analysis/diversity/beta.py
@@ -245,7 +245,10 @@ class BetaDiversity(DiversityBase, ABC):
         """
 
         filtered_metadata_df = self._get_filtered_df_from_metadata(metadata_df)
-        df = pd.concat([self.pcoa.samples, filtered_metadata_df[group_col]], axis=1)
+        if group_col2:
+            df = pd.concat([self.pcoa.samples, filtered_metadata_df[[group_col, group_col2]]], axis=1)
+        else:
+            df = pd.concat([self.pcoa.samples, filtered_metadata_df[group_col]], axis=1)
 
         if mode not in ['scatter', 'scatter3d']:
             logger.warning("%s not a available mode, set to default (scatter)", mode)

--- a/moonstone/analysis/diversity/beta.py
+++ b/moonstone/analysis/diversity/beta.py
@@ -142,7 +142,6 @@ class BetaDiversity(DiversityBase, ABC):
             # Center features with respect to samples so ploting fisuals make sense
             positive_feature_correction = pcoa_sample_coordinates_df[axis].max() - d_pbf[axis].max()
             d_pbf[axis] = d_pbf[axis] + positive_feature_correction
-
         return d_pbf
 
     def _map_loadings(self, pci, n):
@@ -171,11 +170,6 @@ class BetaDiversity(DiversityBase, ABC):
             fig.add_annotation(x=pcx[m]*1.1, y=pcy[m]*1.1, text=formatted_text,
                                ay=0, font={"color": "black", "size": 14})
         return fig
-
-    def _calculate_base_cone_1coor(self, single_coor, d):
-        if single_coor < 0:
-            return single_coor + d
-        return single_coor - d
 
     def _bi_plotly3d(self, fig, pcx, pcy, pcz, features, n):
         """
@@ -243,7 +237,6 @@ class BetaDiversity(DiversityBase, ABC):
             proportions: write proportion explained for each PC in the x/y labels.
             n_biplot_features: add arrows showing the n most explanatory features per axis direction
         """
-
         filtered_metadata_df = self._get_filtered_df_from_metadata(metadata_df)
         if group_col2:
             df = pd.concat([self.pcoa.samples, filtered_metadata_df[[group_col, group_col2]]], axis=1)
@@ -251,7 +244,7 @@ class BetaDiversity(DiversityBase, ABC):
             df = pd.concat([self.pcoa.samples, filtered_metadata_df[group_col]], axis=1)
 
         if mode not in ['scatter', 'scatter3d']:
-            logger.warning("%s not a available mode, set to default (scatter)", mode)
+            logger.warning("'%s' not a available mode, set to default (scatter).", mode)
             mode = "scatter"
 
         title = f"PCOA of samples from {self.index_name} distance matrix"
@@ -303,7 +296,6 @@ class BetaDiversity(DiversityBase, ABC):
             my_pcoa_biplot = pcoa_biplot(self.pcoa, self.df.transpose())
             d_bf = my_pcoa_biplot.features                           # DF of PCoA feature contributions
             d_sbf = self._scale_biplot(d_bf, self.pcoa.samples)      # DF of SCALLED PCoA features contribution
-
             loadings = d_sbf.transpose().values
             pcx = loadings[x_pc-1, :]
             pcy = loadings[y_pc-1, :]

--- a/moonstone/analysis/diversity/beta.py
+++ b/moonstone/analysis/diversity/beta.py
@@ -2,10 +2,12 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Union
 
+import numpy as np
 import pandas as pd
+import plotly.graph_objects as go
 import skbio.diversity
 from skbio.stats.distance import DistanceMatrix
-from skbio.stats.ordination import pcoa
+from skbio.stats.ordination import pcoa, pcoa_biplot
 
 from moonstone.analysis.diversity.base import (
     DiversityBase, PhylogeneticDiversityBase
@@ -94,7 +96,7 @@ class BetaDiversity(DiversityBase, ABC):
         return pd.concat(df_list).dropna()
 
     def _get_grouped_df(self, metadata_df):
-        if type(metadata_df) == pd.core.series.Series:
+        if type(metadata_df) is pd.core.series.Series:
             return self._get_grouped_df_series(metadata_df)
         else:
             return self._get_grouped_df_dataframe(metadata_df)
@@ -104,21 +106,137 @@ class BetaDiversity(DiversityBase, ABC):
         if getattr(self, '_pcoa', None) is None:
             self._pcoa = pcoa(self.beta_diversity)
         return self._pcoa
-    
+
     def _label_with_proportion(self, var):
         string = "{} ({:2.2%})".format(var, self.pcoa.proportion_explained[var])
         return string
+
+    def _unit_scale(self, x, y, scale=1):
+        """
+        Scales to a range of 1 to -1.
+        Each value for a given component, x, is divided by the range of values of that same component, y.
+        """
+        z = x/y * scale
+        return z
+
+    def _scale_biplot(self, pcoa_biplot_features_df, pcoa_sample_coordinates_df) -> pd.DataFrame:
+        """
+        skbio PCoA defaults to a scale of 1 (e.g. -1 to 0, 0 to 1, -0.5 to 0.5, -0.3 to 0.7, etc...)
+        This functions first calls the UNIT_SCALE function. It then centers the features to match the
+        PCoA figure scaling so as to generate an accurate overlay of features and samples.
+
+        Calculations and scaling is done individually for each axis.
+        """
+        d_pbf = pcoa_biplot_features_df
+
+        for axis in d_pbf.columns:  # for each principle coordinate (PC)
+            # Get the range of coordinates for the samples
+            pcoa_range = abs(pcoa_sample_coordinates_df[axis].min()) + abs(pcoa_sample_coordinates_df[axis].max())
+
+            # Feature have a range of 1.0, and so we scale this to sample range
+            d_pbf[axis] = self._unit_scale(
+                d_pbf[axis],
+                d_pbf[axis].max() - d_pbf[axis].min(),
+                scale=pcoa_range)
+
+            # Center features with respect to samples so ploting fisuals make sense
+            positive_feature_correction = pcoa_sample_coordinates_df[axis].max() - d_pbf[axis].max()
+            d_pbf[axis] = d_pbf[axis] + positive_feature_correction
+
+        return d_pbf
+
+    def _map_loadings(self, pci, n):
+        pci_pos = list(np.argsort(pci)[-n:])  # Sorts values but returns the argument position!
+        pci_neg = list(np.argsort(pci)[:n])   # Allows alignment with feature name.
+        return pci_pos, pci_neg
+
+    def _bi_plotly(self, fig, pcx, pcy, features, n):
+        """
+        Args:
+            loadings: is the vector for each indiviudal variable (columns) in as many dimentions as PCs (rows).
+            n: Number of individual loadings to plot.
+        """
+
+        pcx_pos, pcx_neg = self._map_loadings(pcx, n)
+        pcy_pos, pcy_neg = self._map_loadings(pcy, n)
+        map_loadings = set(pcx_pos + pcx_neg + pcy_pos + pcy_neg)
+
+        for m in map_loadings:
+            fig.add_annotation(x=pcx[m], y=pcy[m], showarrow=True, arrowhead=2, arrowwidth=2,
+                               axref='x', ayref='y', ax=0, ay=0)
+            if type(features[m]) is str:
+                formatted_text = f"{features[m]}"
+            else:
+                formatted_text = f"{features[m][-1]}"  # Handle multi-index parts
+            fig.add_annotation(x=pcx[m]*1.1, y=pcy[m]*1.1, text=formatted_text,
+                               ay=0, font={"color": "black", "size": 14})
+        return fig
+
+    def _calculate_base_cone_1coor(self, single_coor, d):
+        if single_coor < 0:
+            return single_coor + d
+        return single_coor - d
+
+    def _bi_plotly3d(self, fig, pcx, pcy, pcz, features, n):
+        """
+        Args:
+            loadings: is the vector for each indiviudal variable (columns) in as many dimentions as PCs (rows).
+            n: Number of individual loadings to plot.
+        """
+        pcx_pos, pcx_neg = self._map_loadings(pcx, n)
+        pcy_pos, pcy_neg = self._map_loadings(pcy, n)
+        pcz_pos, pcz_neg = self._map_loadings(pcz, n)
+        map_loadings = set(pcx_pos + pcx_neg + pcy_pos + pcy_neg + pcz_pos + pcz_neg)
+
+        annotations = []
+        for m in map_loadings:
+            if type(features[m]) is str:
+                formatted_text = f"{features[m]}"
+            else:
+                formatted_text = f"{features[m][-1]}"  # Handle multi-index parts
+
+            fig.add_trace(go.Scatter3d(
+                x=[0, pcx[m]],  # Start at (0, 0, 0) and go to (x, y, z)
+                y=[0, pcy[m]],
+                z=[0, pcz[m]],
+                mode='lines', line=dict(color='black', width=2),
+                showlegend=False
+            ))
+
+            # Add annotation near the arrowhead
+            fig.add_trace(go.Scatter3d(
+                x=[pcx[m]*1.1], y=[pcy[m]*1.1], z=[pcz[m]*1.1],
+                mode='text', text=[formatted_text], textposition='top center',
+                showlegend=False
+            ))
+
+            fig.add_trace(go.Cone(
+                x=[pcx[m]],
+                y=[pcy[m]],
+                z=[pcz[m]],
+                u=[pcx[m]],
+                v=[pcy[m]],
+                w=[pcz[m]],
+                sizeref=0.05,  # Adjust size of the cone
+                showlegend=False,
+                showscale=False,
+                colorscale=[[0, 'rgb(0,0,0)'], [1, 'rgb(0,0,0)']]
+                ))
+
+        fig.update_layout(scene={"annotations": annotations})
+        return fig
 
     def visualize_pcoa(
         self, metadata_df: pd.DataFrame, group_col: str, mode: str = 'scatter',
         proportions: bool = False, x_pc: int = 1, y_pc: int = 2, z_pc: int = 3,
         show: bool = True, output_file: Union[bool, str] = False,
         colors: dict = None, groups: list = None,
-        plotting_options: dict = None,
+        n_biplot_features: int = 0, plotting_options: dict = None,
     ):
         """
         Args:
             proportions: write proportion explained for each PC in the x/y labels.
+            n_biplot_features: add arrows showing the n most explanatory features per axis direction
         """
 
         filtered_metadata_df = self._get_filtered_df_from_metadata(metadata_df)
@@ -127,7 +245,7 @@ class BetaDiversity(DiversityBase, ABC):
         if mode not in ['scatter', 'scatter3d']:
             logger.warning("%s not a available mode, set to default (scatter)", mode)
             mode = "scatter"
-        
+
         title = f"PCOA of samples from {self.index_name} distance matrix"
         xvar = "PC"+str(x_pc)
         yvar = "PC"+str(y_pc)
@@ -137,7 +255,13 @@ class BetaDiversity(DiversityBase, ABC):
         else:
             xlabel = xvar
             ylabel = yvar
-        
+
+        if n_biplot_features > 0:
+            tmp_show = False
+            tmp_output_file = False
+        else:
+            tmp_show = show
+            tmp_output_file = output_file
 
         if mode == "scatter":
             plotting_options = self._handle_plotting_options(
@@ -145,22 +269,42 @@ class BetaDiversity(DiversityBase, ABC):
             )
             graph = GroupScatterGraph(df)
             args_for_plot = [xvar, yvar, group_col]
-        elif mode == "scatter3d":
+        else:                       # mode == "scatter3d"
             zvar = "PC"+str(z_pc)
-            zlabel = self._label_with_proportion(zvar)
+            if proportions:
+                zlabel = self._label_with_proportion(zvar)
+            else:
+                zlabel = zvar
             plotting_options = self._handle_plotting_options(
                 plotting_options, title, xlabel, ylabel, False, zlabel=zlabel
             )
             graph = GroupScatter3DGraph(df)
             args_for_plot = [xvar, yvar, zvar, group_col]
-        graph.plot_one_graph(
+        fig = graph.plot_one_graph(
             *args_for_plot,
             plotting_options=plotting_options,
-            show=show,
-            output_file=output_file,
+            show=tmp_show,
+            output_file=tmp_output_file,
             colors=colors,
             groups=groups,
         )
+
+        if n_biplot_features > 0:
+            my_pcoa_biplot = pcoa_biplot(self.pcoa, self.df.transpose())
+            d_bf = my_pcoa_biplot.features                           # DF of PCoA feature contributions
+            d_sbf = self._scale_biplot(d_bf, self.pcoa.samples)      # DF of SCALLED PCoA features contribution
+
+            loadings = d_sbf.transpose().values
+            pcx = loadings[x_pc-1, :]
+            pcy = loadings[y_pc-1, :]
+            if mode == "scatter3d":
+                pcz = loadings[z_pc-1, :]
+                fig = self._bi_plotly3d(fig, pcx, pcy, pcz, d_bf.index, n_biplot_features)
+            else:
+                fig = self._bi_plotly(fig, pcx, pcy, d_bf.index, n_biplot_features)
+
+            graph._handle_output_plotly(fig, show, output_file)
+        return fig, d_bf, self.pcoa.samples
 
 
 class BrayCurtis(BetaDiversity):
@@ -173,6 +317,15 @@ class BrayCurtis(BetaDiversity):
         """
         # steps to compute the index
         return skbio.diversity.beta_diversity("braycurtis", df.transpose(), df.columns)
+
+
+class Jaccard(BetaDiversity):
+    """
+    Perform calculation of the Jaccard distance for each pairs of samples from the dataframe
+    """
+    def compute_beta_diversity(self, df):
+        # steps to compute the index
+        return skbio.diversity.beta_diversity("jaccard", df.transpose(), df.columns)
 
 
 class WeightedUniFrac(BetaDiversity, PhylogeneticDiversityBase):

--- a/moonstone/analysis/statistical_test.py
+++ b/moonstone/analysis/statistical_test.py
@@ -245,7 +245,7 @@ def _compute_max_nbins_contingency_table(
             numerical_series, categorical_series, nbins,
             cut_type=cut_type, na=na, force_computation=False, warn=False
         )
-        if type(tab) != float:  # type(np.nan) == float
+        if type(tab) is not float:  # type(np.nan) == float
             return tab, nbins
         nbins -= 1
 

--- a/moonstone/core/module_base.py
+++ b/moonstone/core/module_base.py
@@ -18,12 +18,13 @@ class BaseModule(ABC):
     """
 
     def _handle_plotting_options(
-        self, plotting_options: dict, 
-        title: str, xlabel: str, ylabel: str, log_scale: bool, 
+        self, plotting_options: dict,
+        title: str, xlabel: str, ylabel: str, log_scale: bool,
         zlabel: str = None
     ):
         """
-        Update or create plotting options with the title of the graph and of the different axis, as well as the log scale
+        Update or create plotting options with the title of the graph and of the different axis,
+        as well as the log scale
         """
         if plotting_options is None:
             plotting_options = {}

--- a/moonstone/parsers/counts/taxonomy/metaphlan.py
+++ b/moonstone/parsers/counts/taxonomy/metaphlan.py
@@ -122,7 +122,9 @@ class Metaphlan3Parser(BaseMetaphlanParser):
     taxa_column = 'clade_name'
     NCBI_tax_column = 'NCBI_tax_id'
 
-    def __init__(self, *args, analysis_type: str = 'rel_ab', keep_NCBI_tax_col: bool = False, skiprows: int = 1, **kwargs):
+    def __init__(
+        self, *args, analysis_type: str = 'rel_ab', keep_NCBI_tax_col: bool = False, skiprows: int = 1, **kwargs
+    ):
         """
         Args:
             analysis_type: output type of Metaphlan3 (see ``-t`` option of metaphlan3)

--- a/moonstone/plot/counts.py
+++ b/moonstone/plot/counts.py
@@ -234,7 +234,7 @@ class PlotTaxonomyCounts:
         prec = -0.5
         subgps = sep_series.unique()
         for subgp in subgps:
-            if type(subgp) != str and np.isnan(subgp):
+            if type(subgp) is not str and np.isnan(subgp):
                 df_gp = top_and_other_df[sep_series[sep_series.isna()].index.intersection(top_and_other_df.columns)]
             else:
                 df_gp = top_and_other_df[sep_series[sep_series == subgp].index.intersection(top_and_other_df.columns)]

--- a/moonstone/plot/counts.py
+++ b/moonstone/plot/counts.py
@@ -772,7 +772,7 @@ samples"
                 fig = graph.plot_one_graph(plotting_options=plotting_options, **kwargs, show=False)
             else:
                 fig = graph.plot_complex_graph(color_df, plotting_options=plotting_options, **kwargs, show=False)
-            fig = add_groups_annotations(fig, x_coor, subgps)
+            fig = add_groups_annotations(fig, x_coor, (0, 100, 104), subgps)
             graph._handle_output_plotly(fig, show, output_file)
         else:
             if color_df is None:

--- a/moonstone/plot/graphs/bargraph.py
+++ b/moonstone/plot/graphs/bargraph.py
@@ -89,7 +89,7 @@ class MatrixBarGraph(BaseGraph):
         lbls = list(metadata_ser.unique())
         lbls.sort(reverse=True)
         for lbl in lbls:
-            if type(lbl) != str and np.isnan(lbl):
+            if type(lbl) is not str and np.isnan(lbl):
                 dfp = pd.DataFrame(
                     metadata_ser.loc[self.data.columns][
                         metadata_ser.loc[self.data.columns].isna()

--- a/moonstone/plot/graphs/base.py
+++ b/moonstone/plot/graphs/base.py
@@ -45,14 +45,14 @@ class BaseGraph(ABC):
     ) -> dict:
         """
         Generate a dictionary with the different groups as key and a color as value.
-        If number of different groups > 38, then colors are repeted.
+        If number of different groups > 38, then colors are repeated.
 
-            Args:
-                - metadata: Can take DataFrame or Series, then all different values are listed and assigned a color.
-                  Or can take a list/array, then all elements of the list are assigned a color.
-                  Finally, metadata can be an integer which act like a list ranging from 0 to that integer (excluded),
-                  and each integer is assigned a color.
-                - colors: Dictionary that dictate a particular color to a particular group.
+        Args:
+            metadata: Can take DataFrame or Series, then all different values are listed and assigned a color.
+                Or can take a list/array, then all elements of the list are assigned a color.
+                Finally, metadata can be an integer which act like a list ranging from 0 to that integer (excluded),
+                and each integer is assigned a color.
+            colors: Dictionary that dictate a particular color to a particular group.
         """
         final_colors = {}
         if isinstance(metadata, pd.Series):

--- a/moonstone/plot/graphs/base.py
+++ b/moonstone/plot/graphs/base.py
@@ -63,7 +63,7 @@ class BaseGraph(ABC):
                 all_gp += list(metadata[cc].unique())
             all_gp = list(set(all_gp))  # doesn't remove all different nan
         # we can't do it manually because then some nan don't correspond to the one manually added
-        elif type(metadata) == int:
+        elif type(metadata) is int:
             all_gp = list(range(0, metadata))
         else:  # array
             all_gp = metadata

--- a/moonstone/plot/graphs/base.py
+++ b/moonstone/plot/graphs/base.py
@@ -6,6 +6,7 @@ import pandas as pd
 import plotly.io
 import plotly.express as px
 import plotly.graph_objects as go
+from plotly.validators.scatter.marker import SymbolValidator
 
 import logging
 
@@ -169,6 +170,129 @@ class GroupBaseGraph(BaseGraph):
 
     def _get_group_color(self, group: str, group_color: dict):
         return group_color.get(group, self.DEFAULT_COLOR)
+
+    @property
+    def dictionary_marker_symbols(self):
+        """
+        Dictionary of all the symbols accepted by a scatter (or other) plot.
+        key is the name of the symbol and value is its number
+        ex: {'circle': 0, 'circle-open': 100, ...}
+        """
+        if getattr(self, '_dictionary_marker_symbols', None) is None:
+            raw_symbols = SymbolValidator().values
+            self._dictionary_marker_symbols = {}
+            for i in range(0, len(raw_symbols), 3):
+                self._dictionary_marker_symbols[raw_symbols[i+2]] = raw_symbols[i]
+        return self._dictionary_marker_symbols
+
+    def _translating_forced_symbols(self, forced_symbols: Union[list, set]) -> set:
+        translated_symbols = []
+        txt_symbols = []
+        for x in forced_symbols:
+            if type(x) is int:
+                translated_symbols += [x]
+            elif x.isnumeric():
+                translated_symbols += [int(x)]
+            else:
+                txt_symbols += [x]
+
+        if len(txt_symbols) > 0:
+            for i in txt_symbols:
+                if i in self.dictionary_marker_symbols.keys():
+                    translated_symbols += [self.dictionary_marker_symbols[i]]
+                    # txt_symbols.remove(i)
+                else:
+                    # raise error
+                    error_message = f"Invalid symbol values: {txt_symbols}.\n\
+Accepted values: {SymbolValidator().values}"
+                    raise ValueError(error_message)
+        return set(translated_symbols)
+
+    def _symbol_scheme(self, groups: list, symbols: dict = None):
+        """
+        Generate a dictionary with the different groups as key and an int corresponding to a symbol (following
+        go.Marker's definition) as value.
+        If number of different groups > 162, then symbols are repeated.
+
+        Args:
+            metadata: Can take DataFrame or Series, then all different values are listed and assigned a color.
+                Or can take a list/array, then all elements of the list are assigned a color.
+                Finally, metadata can be an integer which act like a list ranging from 0 to that integer (excluded),
+                and each integer is assigned a color.
+            symbols: Dictionary that dictate a particular symbol to a particular group.
+        """
+        if symbols is not None and len(set(groups).difference(symbols.keys())) == 0:
+            return symbols
+
+        if len(groups) > 162:
+            list_symbols = list(self.dictionary_marker_symbols.values())
+            dic_symbols = dict(zip(groups, list_symbols * (int(len(groups) / len(list_symbols)) + 1)))
+        else:
+            if len(groups) <= 72:
+                list_fill_pattern = ["", "1", "3"]     # 2 is filled with a dot inside ("-dot")
+                # but it is not very clear
+                list_shape = [
+                    "00", "01", "02", "03", "04", "05", "06", "17", "13", "18", "07", "08", "14", "23", "24", "19",
+                    "20", "21", "22", "16", "09", "10", "11", "12", "15",
+                ]
+                n = -(-len(groups) // 3)
+                if n <= 8:
+                    n = 8
+
+                list_symbols = [int(prefix + suffix) for prefix in list_fill_pattern for suffix in list_shape[:n]]
+            else:
+                list_symbols = self.dictionary_marker_symbols.values()
+
+            if symbols is not None:
+                to_remove = self._translating_forced_symbols(set(symbols.values()))
+
+                # for reusability, we can't use set().difference()
+                list_symbols = [x for x in list_symbols if x not in to_remove]
+                skeys = set(symbols.keys())
+                groups = [x for x in groups if x not in skeys]
+            dic_symbols = dict(zip(groups, list_symbols))
+
+        if symbols is not None:
+            dic_symbols.update(**symbols)
+
+        return dic_symbols
+
+    def _symbol_scheme3d(self, groups: list, symbols: dict = None):
+        """
+        Generate a dictionary with the different groups as key and the name of a symbol as value.
+        If number of different groups > 8, then symbols are repeated.
+        NB: Unlike for the 2D plots that accept 162 different symbols, 3D plots accept only 8 different symbols
+        and only their name (and not their number).
+
+        Args:
+            metadata: Can take DataFrame or Series, then all different values are listed and assigned a color.
+                Or can take a list/array, then all elements of the list are assigned a color.
+                Finally, metadata can be an integer which act like a list ranging from 0 to that integer (excluded),
+                and each integer is assigned a color.
+            symbols: Dictionary that dictate a particular symbol to a particular group.
+        """
+        if symbols is not None and len(set(groups).difference(symbols.keys())) == 0:
+            return symbols
+
+        accepted_symbols = [
+            'circle', 'cross', 'diamond', 'square',
+            'circle-open', 'diamond-open', 'square-open',
+            'x'  # this one is crazy big so let's put it as the last resort
+        ]
+        if len(groups) > 8:
+            dic_symbols = dict(zip(groups, accepted_symbols * (int(len(groups) / len(accepted_symbols)) + 1)))
+        else:
+            if symbols is not None:
+                # for reusability, we can't use set().difference()
+                accepted_symbols = [x for x in accepted_symbols if x not in symbols.values()]
+                skeys = set(symbols.keys())
+                groups = [x for x in groups if x not in skeys]
+            dic_symbols = dict(zip(groups, accepted_symbols))
+
+        if symbols is not None:
+            dic_symbols.update(**symbols)
+
+        return dic_symbols
 
     @abstractmethod
     def _gen_fig_trace(self, x: list, y: list, name: str, text: list, color: str):

--- a/moonstone/plot/graphs/scatter.py
+++ b/moonstone/plot/graphs/scatter.py
@@ -2,6 +2,7 @@ import logging
 from typing import Union
 
 import plotly.graph_objects as go
+from plotly.validators.scatter.marker import SymbolValidator
 
 from moonstone.plot.graphs.base import BaseGraph, GroupBaseGraph
 
@@ -60,24 +61,86 @@ class GroupScatterGraph(GroupBaseGraph):
             marker=marker,
         )
 
-    def _symbol_scheme(self, groups: list):
-        list_fill_pattern = ["", "1", "3"]     # 2 is filled with a dot inside ("-dot")
-        # but it is not very clear
-        list_shape = [
-            "00", "01", "02", "03", "04", "05", "06", "17",
-            # add some more in case of more than 24 groups
-        ]
+    @property
+    def dictionary_marker_symbols(self):
+        """
+        All the symbols accepted by scatter as integer.
+        """
+        if getattr(self, '_dictionary_marker_symbols', None) is None:
+            raw_symbols = SymbolValidator().values
+            self._dictionary_marker_symbols = {}
+            for i in range(0, len(raw_symbols), 3):
+                self._dictionary_marker_symbols[raw_symbols[i+2]] = raw_symbols[i]
+        return self._dictionary_marker_symbols
 
-        # if I ever bring myself to class more shape, I'll uncomment below:
-        # to get my 8 fave shape first
-        # if len(groups) <= 24:
-        #   list_shape = list_shape[:8]
+    def _translating_forced_symbols(self, forced_symbols: Union[list, set]) -> set:
+        translated_symbols = []
+        txt_symbols = []
+        for x in forced_symbols:
+            if type(x) is int:
+                translated_symbols += [x]
+            elif x.isnumeric():
+                translated_symbols += [int(x)]
+            else:
+                txt_symbols += [x]
 
-        list_symbols = [int(prefix + suffix) for prefix in list_fill_pattern for suffix in list_shape]
-        if len(groups) <= 24:
-            return dict(zip(groups, list_symbols))
+        if len(txt_symbols) > 0:
+            for i in txt_symbols:
+                if i in self.dictionary_marker_symbols.keys():
+                    translated_symbols += [self.dictionary_marker_symbols[i]]
+                    # txt_symbols.remove(i)
+                else:
+                    # raise error
+                    error_message = f"Invalid symbol values: {txt_symbols}.\n\
+Accepted values: {SymbolValidator().values}"
+                    raise ValueError(error_message)
+        return set(translated_symbols)
+
+    def _symbol_scheme(self, groups: list, symbols: dict = None):
+        """
+        Generate a dictionary with the different groups as key and an int corresponding to a symbol (following
+        go.Marker's definition) as value.
+        If number of different groups > 24, then symbols are repeated.
+
+        Args:
+            metadata: Can take DataFrame or Series, then all different values are listed and assigned a color.
+                Or can take a list/array, then all elements of the list are assigned a color.
+                Finally, metadata can be an integer which act like a list ranging from 0 to that integer (excluded),
+                and each integer is assigned a color.
+            symbols: Dictionary that dictate a particular symbol to a particular group.
+        """
+        if len(groups) > 162:
+            list_symbols = list(self.dictionary_marker_symbols.values())
+            dic_symbols = dict(zip(groups, list_symbols * (int(len(groups) / len(list_symbols)) + 1)))
         else:
-            return dict(zip(groups, list_symbols * (int(len(groups) / len(list_symbols)) + 1)))
+            if len(groups) <= 72:
+                list_fill_pattern = ["", "1", "3"]     # 2 is filled with a dot inside ("-dot")
+                # but it is not very clear
+                list_shape = [
+                    "00", "01", "02", "03", "04", "05", "06", "17", "13", "18", "07", "08", "14", "23", "24", "19",
+                    "20", "21", "22", "16", "09", "10", "11", "12", "15",
+                ]
+                n = -(-len(groups) // 3)
+                if n <= 8:
+                    n = 8
+
+                list_symbols = [int(prefix + suffix) for prefix in list_fill_pattern for suffix in list_shape[:n]]
+            else:
+                list_symbols = self.dictionary_marker_symbols.values()
+
+            if symbols is not None:
+                to_remove = self._translating_forced_symbols(set(symbols.values()))
+
+                # for reusability, we can't use set().difference()
+                list_symbols = [x for x in list_symbols if x not in to_remove]
+                skeys = set(symbols.keys())
+                groups = [x for x in groups if x not in skeys]
+            dic_symbols = dict(zip(groups, list_symbols))
+
+        if symbols is not None:
+            dic_symbols.update(**symbols)
+
+        return dic_symbols
 
     def plot_one_graph(
         self,
@@ -117,7 +180,7 @@ class GroupScatterGraph(GroupBaseGraph):
                         self._gen_fig_trace(
                             filtered_df[first_col],
                             filtered_df[second_col],
-                            str(gp1),
+                            str(gp1)+" - "+str(gp2),
                             filtered_df.index,
                             self._get_group_color(gp1, colors),
                             marker=dict(symbol=dic_symbol[gp2]),

--- a/moonstone/plot/graphs/scatter.py
+++ b/moonstone/plot/graphs/scatter.py
@@ -48,6 +48,7 @@ class GroupScatterGraph(GroupBaseGraph):
         name: str,
         text: list,
         color: str,
+        marker: dict = None
     ) -> go.Scatter:
         return go.Scatter(
             x=x,
@@ -56,18 +57,40 @@ class GroupScatterGraph(GroupBaseGraph):
             text=text,
             marker_color=color,
             mode="markers",
+            marker=marker,
         )
+
+    def _symbol_scheme(self, groups: list):
+        list_fill_pattern = ["", "1", "3"]     # 2 is filled with a dot inside ("-dot")
+        # but it is not very clear
+        list_shape = [
+            "00", "01", "02", "03", "04", "05", "06", "17",
+            # add some more in case of more than 24 groups
+        ]
+
+        # if I ever bring myself to class more shape, I'll uncomment below:
+        # to get my 8 fave shape first
+        # if len(groups) <= 24:
+        #   list_shape = list_shape[:8]
+
+        list_symbols = [int(prefix + suffix) for prefix in list_fill_pattern for suffix in list_shape]
+        if len(groups) <= 24:
+            return dict(zip(groups, list_symbols))
+        else:
+            return dict(zip(groups, list_symbols * (int(len(groups) / len(list_symbols)) + 1)))
 
     def plot_one_graph(
         self,
         first_col: str,
         second_col: str,
         group_col: str,
+        group_col2: str = None,
         plotting_options: dict = None,
         show: bool = True,
         output_file: Union[bool, str] = False,
         colors: dict = None,
         groups: list = None,
+        groups2: list = None,
         **kwargs
     ) -> go.Figure:
         """
@@ -79,20 +102,41 @@ class GroupScatterGraph(GroupBaseGraph):
             groups = list(self.data[group_col].unique())
         if colors is None:
             colors = self._gen_default_color_dict(groups)
+        if group_col2 and groups2 is None:
+            groups2 = list(self.data[group_col2].unique())
+
         fig = go.Figure()
 
-        for group in groups:
-            filtered_df = self.data[self.data[group_col] == group]
-            fig.add_trace(
-                self._gen_fig_trace(
-                    filtered_df[first_col],
-                    filtered_df[second_col],
-                    str(group),
-                    filtered_df.index,
-                    self._get_group_color(group, colors),
-                    **kwargs,
+        if group_col2:
+            dic_symbol = self._symbol_scheme(groups2)
+            for gp2 in groups2:
+                gp2_filtered_df = self.data[self.data[group_col2] == gp2]
+                for gp1 in groups:
+                    filtered_df = gp2_filtered_df[gp2_filtered_df[group_col] == gp1]
+                    fig.add_trace(
+                        self._gen_fig_trace(
+                            filtered_df[first_col],
+                            filtered_df[second_col],
+                            str(gp1),
+                            filtered_df.index,
+                            self._get_group_color(gp1, colors),
+                            marker=dict(symbol=dic_symbol[gp2]),
+                        )
+                    )
+        else:       # = if group_col2 is None
+            for group in groups:
+                filtered_df = self.data[self.data[group_col] == group]
+                fig.add_trace(
+                    self._gen_fig_trace(
+                        filtered_df[first_col],
+                        filtered_df[second_col],
+                        str(group),
+                        filtered_df.index,
+                        self._get_group_color(group, colors),
+                        # **kwargs,  # removing kwargs because I think plotting_options
+                        # is already supposed to get the stuff done
+                    )
                 )
-            )
 
         if plotting_options is not None:
             fig = self._handle_plotting_options_plotly(fig, plotting_options)

--- a/moonstone/plot/graphs/scatter.py
+++ b/moonstone/plot/graphs/scatter.py
@@ -2,7 +2,6 @@ import logging
 from typing import Union
 
 import plotly.graph_objects as go
-from plotly.validators.scatter.marker import SymbolValidator
 
 from moonstone.plot.graphs.base import BaseGraph, GroupBaseGraph
 
@@ -61,87 +60,6 @@ class GroupScatterGraph(GroupBaseGraph):
             marker=marker,
         )
 
-    @property
-    def dictionary_marker_symbols(self):
-        """
-        All the symbols accepted by scatter as integer.
-        """
-        if getattr(self, '_dictionary_marker_symbols', None) is None:
-            raw_symbols = SymbolValidator().values
-            self._dictionary_marker_symbols = {}
-            for i in range(0, len(raw_symbols), 3):
-                self._dictionary_marker_symbols[raw_symbols[i+2]] = raw_symbols[i]
-        return self._dictionary_marker_symbols
-
-    def _translating_forced_symbols(self, forced_symbols: Union[list, set]) -> set:
-        translated_symbols = []
-        txt_symbols = []
-        for x in forced_symbols:
-            if type(x) is int:
-                translated_symbols += [x]
-            elif x.isnumeric():
-                translated_symbols += [int(x)]
-            else:
-                txt_symbols += [x]
-
-        if len(txt_symbols) > 0:
-            for i in txt_symbols:
-                if i in self.dictionary_marker_symbols.keys():
-                    translated_symbols += [self.dictionary_marker_symbols[i]]
-                    # txt_symbols.remove(i)
-                else:
-                    # raise error
-                    error_message = f"Invalid symbol values: {txt_symbols}.\n\
-Accepted values: {SymbolValidator().values}"
-                    raise ValueError(error_message)
-        return set(translated_symbols)
-
-    def _symbol_scheme(self, groups: list, symbols: dict = None):
-        """
-        Generate a dictionary with the different groups as key and an int corresponding to a symbol (following
-        go.Marker's definition) as value.
-        If number of different groups > 24, then symbols are repeated.
-
-        Args:
-            metadata: Can take DataFrame or Series, then all different values are listed and assigned a color.
-                Or can take a list/array, then all elements of the list are assigned a color.
-                Finally, metadata can be an integer which act like a list ranging from 0 to that integer (excluded),
-                and each integer is assigned a color.
-            symbols: Dictionary that dictate a particular symbol to a particular group.
-        """
-        if len(groups) > 162:
-            list_symbols = list(self.dictionary_marker_symbols.values())
-            dic_symbols = dict(zip(groups, list_symbols * (int(len(groups) / len(list_symbols)) + 1)))
-        else:
-            if len(groups) <= 72:
-                list_fill_pattern = ["", "1", "3"]     # 2 is filled with a dot inside ("-dot")
-                # but it is not very clear
-                list_shape = [
-                    "00", "01", "02", "03", "04", "05", "06", "17", "13", "18", "07", "08", "14", "23", "24", "19",
-                    "20", "21", "22", "16", "09", "10", "11", "12", "15",
-                ]
-                n = -(-len(groups) // 3)
-                if n <= 8:
-                    n = 8
-
-                list_symbols = [int(prefix + suffix) for prefix in list_fill_pattern for suffix in list_shape[:n]]
-            else:
-                list_symbols = self.dictionary_marker_symbols.values()
-
-            if symbols is not None:
-                to_remove = self._translating_forced_symbols(set(symbols.values()))
-
-                # for reusability, we can't use set().difference()
-                list_symbols = [x for x in list_symbols if x not in to_remove]
-                skeys = set(symbols.keys())
-                groups = [x for x in groups if x not in skeys]
-            dic_symbols = dict(zip(groups, list_symbols))
-
-        if symbols is not None:
-            dic_symbols.update(**symbols)
-
-        return dic_symbols
-
     def plot_one_graph(
         self,
         first_col: str,
@@ -152,6 +70,7 @@ Accepted values: {SymbolValidator().values}"
         show: bool = True,
         output_file: Union[bool, str] = False,
         colors: dict = None,
+        symbols: dict = None,
         groups: list = None,
         groups2: list = None,
         **kwargs
@@ -171,21 +90,22 @@ Accepted values: {SymbolValidator().values}"
         fig = go.Figure()
 
         if group_col2:
-            dic_symbol = self._symbol_scheme(groups2)
+            dic_symbol = self._symbol_scheme(groups2, symbols)
             for gp2 in groups2:
                 gp2_filtered_df = self.data[self.data[group_col2] == gp2]
                 for gp1 in groups:
                     filtered_df = gp2_filtered_df[gp2_filtered_df[group_col] == gp1]
-                    fig.add_trace(
-                        self._gen_fig_trace(
-                            filtered_df[first_col],
-                            filtered_df[second_col],
-                            str(gp1)+" - "+str(gp2),
-                            filtered_df.index,
-                            self._get_group_color(gp1, colors),
-                            marker=dict(symbol=dic_symbol[gp2]),
+                    if not filtered_df.empty:
+                        fig.add_trace(
+                            self._gen_fig_trace(
+                                filtered_df[first_col],
+                                filtered_df[second_col],
+                                str(gp1)+" - "+str(gp2),
+                                filtered_df.index,
+                                self._get_group_color(gp1, colors),
+                                marker=dict(symbol=dic_symbol[gp2]),
+                            )
                         )
-                    )
         else:       # = if group_col2 is None
             for group in groups:
                 filtered_df = self.data[self.data[group_col] == group]
@@ -253,6 +173,7 @@ class GroupScatter3DGraph(GroupBaseGraph):
         name: str,
         text: list,
         color: str,
+        marker: dict = None
     ) -> go.Scatter3d:
         return go.Scatter3d(
             x=x,
@@ -262,6 +183,7 @@ class GroupScatter3DGraph(GroupBaseGraph):
             text=text,
             marker_color=color,
             mode="markers",
+            marker=marker
         )
 
     def plot_one_graph(
@@ -270,10 +192,13 @@ class GroupScatter3DGraph(GroupBaseGraph):
         second_col: str,
         third_col: str,
         group_col: str,
+        group_col2: str = None,
         show: bool = True,
         output_file: Union[bool, str] = False,
         colors: dict = None,
+        symbols: dict = None,
         groups: list = None,
+        groups2: list = None,
         plotting_options: dict = None,
         **kwargs
     ) -> go.Figure:
@@ -287,21 +212,43 @@ class GroupScatter3DGraph(GroupBaseGraph):
             groups = list(self.data[group_col].unique())
         if colors is None:
             colors = self._gen_default_color_dict(groups)
+        if group_col2 and groups2 is None:
+            groups2 = list(self.data[group_col2].unique())
+
         fig = go.Figure()
 
-        for group in groups:
-            filtered_df = self.data[self.data[group_col] == group]
-            fig.add_trace(
-                self._gen_fig_trace(
-                    filtered_df[first_col],
-                    filtered_df[second_col],
-                    filtered_df[third_col],
-                    str(group),
-                    filtered_df.index,
-                    self._get_group_color(group, colors),
-                    **kwargs,
+        if group_col2:
+            dic_symbol = self._symbol_scheme3d(groups2, symbols)
+            for gp2 in groups2:
+                gp2_filtered_df = self.data[self.data[group_col2] == gp2]
+                for gp1 in groups:
+                    filtered_df = gp2_filtered_df[gp2_filtered_df[group_col] == gp1]
+                    if not filtered_df.empty:
+                        fig.add_trace(
+                            self._gen_fig_trace(
+                                filtered_df[first_col],
+                                filtered_df[second_col],
+                                filtered_df[third_col],
+                                str(gp1)+" - "+str(gp2),
+                                filtered_df.index,
+                                self._get_group_color(gp1, colors),
+                                marker=dict(symbol=dic_symbol[gp2]),
+                            )
+                        )
+        else:       # = if group_col2 is None
+            for group in groups:
+                filtered_df = self.data[self.data[group_col] == group]
+                fig.add_trace(
+                    self._gen_fig_trace(
+                        filtered_df[first_col],
+                        filtered_df[second_col],
+                        filtered_df[third_col],
+                        str(group),
+                        filtered_df.index,
+                        self._get_group_color(group, colors),
+                        **kwargs,
+                    )
                 )
-            )
 
         if plotting_options is not None:
             fig = self._handle_plotting_options_plotly(fig, plotting_options)

--- a/moonstone/utils/dict_operations.py
+++ b/moonstone/utils/dict_operations.py
@@ -78,7 +78,7 @@ def flatten_dict(d: MutableMapping, parent_key: str = '', sep: str = '.', flatte
         - parent_key: name of the keys under which d was registered. It is used as prefix for the keys in d.
         - sep: character or string of character used to separate parent_key/prefix and keys of d.
         - flatten_list: should list be flatten. Key would be parent_key followed by position in list.
-          Example: {'a': ['b', 'c']} -> {'a.0': 'b', 'a.1': 'c'} 
+          Example: {'a': ['b', 'c']} -> {'a.0': 'b', 'a.1': 'c'}
     """
     return dict(_flatten_dict_gen(d, parent_key, sep, flatten_list))
 

--- a/moonstone/utils/pandas/series.py
+++ b/moonstone/utils/pandas/series.py
@@ -144,7 +144,7 @@ class SeriesBinning:
 
     @bins_values.setter
     def bins_values(self, bins_values):
-        if type(bins_values) == list and check_list_type(
+        if type(bins_values) is list and check_list_type(
             bins_values, (int, float, np.integer)
         ):
             self._bins_values = bins_values

--- a/moonstone/utils/plot.py
+++ b/moonstone/utils/plot.py
@@ -64,23 +64,28 @@ def add_default_titles_to_plotting_options_3d(
     return plotting_options
 
 
-def add_groups_annotations(fig, x_coor: list, groups: list) -> go.Figure:
+def add_groups_annotations(fig, x_coor: list, y_coor: tuple, groups: list) -> go.Figure:
     """
+    Add labels annotations, in the form of rectangles for the label with text annotations and a line separating the
+    groups going from the bottom of the rectangle to the bottom of the data.
+
     Args
         fig: The figure to which you want to add labels annotation above the data.
         x_coor: List of x coordinates triplet [(x start of background, x of text annotation, x end of background)].
+        y_coor: Tuple of 3 y coordinates : (y bottom of line, y bottom of rectangle, y top of rectangle)
         groups: List of groups' name, should be in the same order as x_coor.
     """
     i = 0
+    y_med = (y_coor[1] + y_coor[2])/2
     color_bg = ["#FFFFFF", "#a7bcdb"]
     while i < len(groups):
         # adding background color
         fig.add_shape(
             type="rect",
             x0=x_coor[i][0],
-            y0=100,
+            y0=y_coor[1],
             x1=x_coor[i][2],
-            y1=104,
+            y1=y_coor[2],
             line=dict(
                 width=0,
             ),
@@ -89,7 +94,7 @@ def add_groups_annotations(fig, x_coor: list, groups: list) -> go.Figure:
         # adding text annotation (group name)
         fig.add_annotation(
             x=x_coor[i][1],
-            y=102,
+            y=y_med,
             xref="x",
             yref="y",
             text=groups[i],
@@ -101,9 +106,9 @@ def add_groups_annotations(fig, x_coor: list, groups: list) -> go.Figure:
             fig.add_shape(
                 type="line",
                 x0=x_coor[i][2],
-                y0=100,
+                y0=y_coor[1],
                 x1=x_coor[i][2],
-                y1=0,
+                y1=y_coor[0],
                 line=dict(width=1, dash="solid", color="white"),
             )
         i += 1

--- a/moonstone/utils/plot.py
+++ b/moonstone/utils/plot.py
@@ -64,7 +64,10 @@ def add_default_titles_to_plotting_options_3d(
     return plotting_options
 
 
-def add_groups_annotations(fig, x_coor: list, y_coor: tuple, groups: list) -> go.Figure:
+def add_groups_annotations(
+    fig, x_coor: list, y_coor: tuple, groups: list,
+    color_bg=["#FFFFFF", "#a7bcdb"],
+) -> go.Figure:
     """
     Add labels annotations, in the form of rectangles for the label with text annotations and a line separating the
     groups going from the bottom of the rectangle to the bottom of the data.
@@ -77,7 +80,7 @@ def add_groups_annotations(fig, x_coor: list, y_coor: tuple, groups: list) -> go
     """
     i = 0
     y_med = (y_coor[1] + y_coor[2])/2
-    color_bg = ["#FFFFFF", "#a7bcdb"]
+    n_cbg = len(color_bg)
     while i < len(groups):
         # adding background color
         fig.add_shape(
@@ -89,7 +92,7 @@ def add_groups_annotations(fig, x_coor: list, y_coor: tuple, groups: list) -> go
             line=dict(
                 width=0,
             ),
-            fillcolor=color_bg[i % 2],
+            fillcolor=color_bg[i % n_cbg],
         )
         # adding text annotation (group name)
         fig.add_annotation(

--- a/tests/analysis/diversity/test_beta.py
+++ b/tests/analysis/diversity/test_beta.py
@@ -237,6 +237,128 @@ class TestBrayCurtis(TestCase):
             output["data"], expected_object,
         )
 
+    def test_unit_scale_with_scale_between0and1(self):
+        tested_object_instance = BrayCurtis(self.tested_object)
+
+        tested_object = pd.DataFrame.from_dict(
+            {
+                'species1': [-30],
+                'species2': [-1],
+                'species3': [-0.2],
+                'species4': [0],
+                'species5': [0.5],
+                'species6': [1],
+                'species7': [198]
+            },
+            orient='index',
+            columns=['PC1']
+        )
+
+        expected_object = pd.DataFrame.from_dict(
+            {
+                'species1': [-0.06],
+                'species2': [-0.002],
+                'species3': [-0.0004],
+                'species4': [0],
+                'species5': [0.001],
+                'species6': [0.002],
+                'species7': [0.396]
+            },
+            orient='index',
+            columns=['PC1']
+        )
+        pd.testing.assert_frame_equal(
+            tested_object_instance._unit_scale(tested_object, 228, 0.456),
+            expected_object
+        )
+
+    def test_unit_scale_with_scale_above1(self):
+        tested_object_instance = BrayCurtis(self.tested_object)
+
+        tested_object = pd.DataFrame.from_dict(
+            {
+                'species1': [-30],
+                'species2': [-1],
+                'species3': [-0.2],
+                'species4': [0],
+                'species5': [0.5],
+                'species6': [1],
+                'species7': [198]
+            },
+            orient='index',
+            columns=['PC1']
+        )
+
+        expected_object = pd.DataFrame.from_dict(
+            {
+                'species1': [-3],
+                'species2': [-0.1],
+                'species3': [-0.02],
+                'species4': [0],
+                'species5': [0.05],
+                'species6': [0.1],
+                'species7': [19.80]
+            },
+            orient='index',
+            columns=['PC1']
+        )
+        pd.testing.assert_frame_equal(
+            tested_object_instance._unit_scale(tested_object, 228, 22.8),
+            expected_object
+        )
+
+    def test_scale_biplot(self):
+        tested_object_instance = BrayCurtis(self.tested_object)
+
+        tested_features_df = pd.DataFrame.from_dict(
+            {
+                ('genusA', 'species1'): [-30, 0],
+                ('genusA', 'species2'): [-1, 89],
+                ('genusB', 'species3'): [-0.2, -5.7],
+                ('genusB', 'species4'): [0, 0],
+                ('genusB', 'species5'): [0.5, 0.32],
+                ('genusC', 'species6'): [1, -0.6],
+                ('genusC', 'species7'): [198, 1]
+            },
+            orient='index',
+            columns=['PC1', 'PC2']
+        )
+        tested_features_df.index = pd.MultiIndex.from_tuples(tested_features_df.index, names=('genus', 'species'))
+
+        tested_samples_df = pd.DataFrame.from_dict(
+            {
+                'sample1': [-6, 3.4],
+                'sample2': [2, 0.9],
+                'sample3': [5, -2.4],
+                'sample4': [13, -0.1],
+                'sample5': [-0.5, 0],
+                'sample6': [-62, -25],
+                'sample7': [0, 0.3]
+            },
+            orient='index',
+            columns=['PC1', 'PC2']
+        )
+
+        expected_object = pd.DataFrame.from_dict(
+            {
+                ('genusA', 'species1'): [-62, -23.290602],
+                ('genusA', 'species2'): [-52.460526, 3.4],
+                ('genusB', 'species3'): [-52.197368, -25],
+                ('genusB', 'species4'): [-52.131579, -23.290602],
+                ('genusB', 'species5'): [-51.967105, -23.194636],
+                ('genusC', 'species6'): [-51.802632, -23.470539],
+                ('genusC', 'species7'): [13, -22.990707]
+            },
+            orient='index',
+            columns=['PC1', 'PC2']
+        )
+        expected_object.index = pd.MultiIndex.from_tuples(expected_object.index, names=('genus', 'species'))
+
+        pd.testing.assert_frame_equal(
+            tested_object_instance._scale_biplot(tested_features_df, tested_samples_df),
+            expected_object
+        )
+
 
 class TestWeightedUniFrac(TestCase):
 

--- a/tests/analysis/diversity/test_beta.py
+++ b/tests/analysis/diversity/test_beta.py
@@ -35,7 +35,7 @@ class TestBrayCurtis(TestCase):
         )
         pd.testing.assert_frame_equal(
             tested_object_instance.beta_diversity_df, expected_object,
-            rtol=0.01
+            rtol=0.01    # set relative tolerance to 0.01 so that 1/3=0.333
             # check_less_precise=2,  # Deprecated since version 1.1.0, to be changed when updating pandas
         )
 
@@ -236,6 +236,9 @@ class TestBrayCurtis(TestCase):
         pd.testing.assert_frame_equal(
             output["data"], expected_object,
         )
+
+#    def test_label_with_proportion(self):
+#
 
     def test_unit_scale_with_scale_between0and1(self):
         tested_object_instance = BrayCurtis(self.tested_object)

--- a/tests/analysis/diversity/test_beta.py
+++ b/tests/analysis/diversity/test_beta.py
@@ -3,6 +3,8 @@ from unittest import TestCase
 from io import StringIO
 import numpy as np
 import pandas as pd
+import plotly.graph_objects as go
+from plotly.graph_objs._cone import Cone
 from skbio import TreeNode
 
 from moonstone.analysis.diversity.beta import (
@@ -419,6 +421,76 @@ class TestBrayCurtis(TestCase):
         np.testing.assert_array_equal(
             result_fig["data"][1]["y"], [0, 0])
 
+    def test_bi_plotly_multiindex(self):
+        # Testing if it works with MultiIndex for the 2d version
+        fig = go.Figure()
+        tested_pcx = [-0.44, 0.52, 0.22, 0.07]
+        tested_pcy = [-0.26, -0.07, -0.04, 0.31]
+        tested_features = pd.MultiIndex.from_tuples(
+            [('genus1', 'species1'), ('genus1', 'species2'), ('genus2', 'species3'), ('genus2', 'species4')],
+            names=['genus', 'species'])
+
+        result_fig = self.tested_object_instance._bi_plotly(fig, tested_pcx, tested_pcy, tested_features, 1)
+        # pcx explained most by:
+        #   * 'species1' in the negative direction
+        #   * 'species2' in the positive direction
+        # pcy explained most by:
+        #   * 'species1' in the negative direction
+        #   * 'species4' in the positive direction
+        # So 3 features shown * 2 (arrow + text) = 6 annotations
+        self.assertEqual(len(result_fig.layout.annotations), 6)
+
+        # checking for one feature
+        # 0 = arrow for first feature
+        self.assertTrue(result_fig.layout.annotations[0].showarrow)
+        self.assertEqual(result_fig.layout.annotations[0].x, -0.44)
+        self.assertEqual(result_fig.layout.annotations[0].y, -0.26)
+        # 1 = text for first feature
+        self.assertEqual(result_fig.layout.annotations[1].text, 'species1')   # the real test here
+
+        # So let's check for the two other features
+        self.assertEqual(result_fig.layout.annotations[3].text, 'species2')
+        self.assertEqual(result_fig.layout.annotations[5].text, 'species4')
+
+    def test_bi_plotly3d_multiindex(self):
+        # Testing if it works with MultiIndex for the 3d version
+        fig = go.Figure()
+        tested_pcx = [-0.44, 0.52, 0.22, 0.07]
+        tested_pcy = [-0.26, -0.07, -0.04, 0.31]
+        tested_pcz = [-0.08, -0.02, 0.18, -0.10]
+        tested_features = pd.MultiIndex.from_tuples(
+            [('genus1', 'species1'), ('genus1', 'species2'), ('genus2', 'species3'), ('genus2', 'species4')],
+            names=['genus', 'species'])
+
+        result_fig = self.tested_object_instance._bi_plotly3d(
+            fig, tested_pcx, tested_pcy, tested_pcz, tested_features, 1)
+        # pcx explained most by:
+        #   * 'species1' in the negative direction
+        #   * 'species2' in the positive direction
+        # pcy explained most by:
+        #   * 'species1' in the negative direction
+        #   * 'species4' in the positive direction
+        # pcz explained most by:
+        #   * 'species4' in the negative direction
+        #   * 'species3' in the positive direction
+        # So 4 features shown * 3 (line + cone + text) = 12 annotations
+        self.assertEqual(len(result_fig.data), 12)
+        # checking for one feature
+        # 0 = line for first feature
+        self.assertTrue(result_fig.data[0].mode, 'lines')
+        self.assertTrue(result_fig.data[0].x, [0, -0.44])
+        self.assertTrue(result_fig.data[0].y, [0, -0.26])
+        self.assertTrue(result_fig.data[0].z, [0, -0.08])
+        # 1 = text for first feature
+        self.assertEqual(result_fig.data[1].text[0], 'species1')
+        # 2 = cone for first feature
+        self.assertEqual(type(result_fig.data[2]), Cone)
+
+        # Let's check for the three other features' name
+        self.assertEqual(result_fig.data[4].text[0], 'species2')
+        self.assertEqual(result_fig.data[7].text[0], 'species3')
+        self.assertEqual(result_fig.data[10].text[0], 'species4')
+
     def test_visualize_pcoa_invalidmode_proportion(self):
         # Checking that proportion work but also giving an invalid mode
         # that will be changed to the default meaning 'scatter'
@@ -515,7 +587,8 @@ set to default (scatter).",
         #   * 'species2' in the positive direction
         # y = pc2 axis explained most by:
         #   * 'species4' in the negative direction
-        #   * 'species1' in the positibe direction        # So 3 features shown * 2 (arrow + text) = 6 annotations
+        #   * 'species1' in the positive direction
+        # So 3 features shown * 2 (arrow + text) = 6 annotations
         self.assertEqual(len(result_fig["layout"]["annotations"]), 6)
 
         # checking one annotation
@@ -598,10 +671,11 @@ set to default (scatter).",
         #   * 'species1' in the negative direction
         #   * 'species2' in the positive direction
         # y = pc2 axis explained most by:
-        #   * 'species4' in the negative direction
-        #   * 'species1' in the positibe direction
+        #   * 'species1' in the negative direction
+        #   * 'species4' in the positive direction
         # z = pc3 axis explained most by:
-        #   * ???
+        #   * 'species4' in the negative direction
+        #   * 'species3' in the positive direction
         # So 4 features shown * 3 (line + cone + text) + 4 groups ("M - A", "M - B", "F - A", "F - B") = 16
         self.assertEqual(len(result_fig.data), 16)
         self.assertEqual(result_fig.layout.scene.xaxis.title.text, 'PC1 (67.37%)')

--- a/tests/analysis/diversity/test_beta.py
+++ b/tests/analysis/diversity/test_beta.py
@@ -6,7 +6,7 @@ import pandas as pd
 from skbio import TreeNode
 
 from moonstone.analysis.diversity.beta import (
-    BrayCurtis, WeightedUniFrac, UnweightedUniFrac
+    BrayCurtis, Jaccard, WeightedUniFrac, UnweightedUniFrac
 )
 
 
@@ -22,9 +22,9 @@ class TestBrayCurtis(TestCase):
             },
             orient='index', columns=['sample1', 'sample2', 'sample3']
         )
+        self.tested_object_instance = BrayCurtis(self.tested_object)
 
     def test_compute_beta_diversity_df(self):
-        tested_object_instance = BrayCurtis(self.tested_object)
         expected_object = pd.DataFrame.from_dict(
             {
                 'sample1': [0, 0.333, 0.714],
@@ -34,14 +34,12 @@ class TestBrayCurtis(TestCase):
             orient='index', columns=['sample1', 'sample2', 'sample3']
         )
         pd.testing.assert_frame_equal(
-            tested_object_instance.beta_diversity_df, expected_object,
+            self.tested_object_instance.beta_diversity_df, expected_object,
             rtol=0.01    # set relative tolerance to 0.01 so that 1/3=0.333
             # check_less_precise=2,  # Deprecated since version 1.1.0, to be changed when updating pandas
         )
 
     def test_compute_beta_diversity_series(self):
-
-        tested_object_instance = BrayCurtis(self.tested_object)
         multi_index = pd.MultiIndex.from_tuples(
             [
                 ('sample1', 'sample2'),
@@ -54,17 +52,15 @@ class TestBrayCurtis(TestCase):
         )
         # Two ways of retrieving the series
         pd.testing.assert_series_equal(
-            tested_object_instance.beta_diversity_series, expected_object,
+            self.tested_object_instance.beta_diversity_series, expected_object,
             rtol=0.01
         )
         pd.testing.assert_series_equal(
-            tested_object_instance.diversity_indexes, expected_object,
+            self.tested_object_instance.diversity_indexes, expected_object,
             rtol=0.01
         )
 
     def test_run_statistical_test_groups_with_NaN(self):
-        tested_object_instance = BrayCurtis(self.tested_object)
-
         tested_df = pd.DataFrame.from_dict(
             {
                 'samples1': [1.88, 'B'],
@@ -103,7 +99,7 @@ class TestBrayCurtis(TestCase):
         )
         expected_object.index.names = ["Group1", "Group2"]
 
-        pval = tested_object_instance._run_statistical_test_groups(
+        pval = self.tested_object_instance._run_statistical_test_groups(
             tested_df, 'Group', stats_test='ttest_independence', correction_method='fdr_bh',
             structure_pval='series', sym=False
             )
@@ -121,14 +117,13 @@ class TestBrayCurtis(TestCase):
             },
             name='sex'
         )
-        tested_object_instance = BrayCurtis(self.tested_object)
         expected_object = pd.DataFrame.from_dict(
             {
                 'sample2-sample3': [1.0, 'F'],
             },
             orient='index', columns=['beta_index', 'sex']
         )
-        output = tested_object_instance._get_grouped_df_series(metadata_ser)
+        output = self.tested_object_instance._get_grouped_df_series(metadata_ser)
         pd.testing.assert_frame_equal(
             output, expected_object,
         )
@@ -182,15 +177,13 @@ class TestBrayCurtis(TestCase):
             },
             orient='index', columns=['sex']
         )
-        tested_object_instance = BrayCurtis(self.tested_object)
-
         expected_object = pd.DataFrame.from_dict(
             {
                 'sample2-sample3': [1.0, 'F'],
             },
             orient='index', columns=['beta_index', 'sex']
         )
-        output = tested_object_instance.analyse_groups(metadata_df, 'sex', show=False, show_pval=False)
+        output = self.tested_object_instance.analyse_groups(metadata_df, 'sex', show=False, show_pval=False)
         pd.testing.assert_frame_equal(
             output['data'], expected_object,
         )
@@ -237,12 +230,35 @@ class TestBrayCurtis(TestCase):
             output["data"], expected_object,
         )
 
-#    def test_label_with_proportion(self):
-#
+    def test_pcoa(self):
+        # So I discovered that pcoa.samples is not identical between my moonstone environment and my jupyter notebook
+        # environment at the 17th decimal. Unsure why...
+        # moonstone environment: python=3.10.16 =/= jupyter notebook environment: python=3.10.14
+        # In both environment: scikit-bio==0.5.9, scikit-learn==1.3.1
+        expected_pcoa_samples = pd.DataFrame.from_dict(
+            {
+                'sample1': [-0.136535, 0.091198, 0.0],
+                'sample2': [-0.431383, -0.064289, 0.0],
+                'sample3': [0.567918, -0.026908, 0.0],
+            },
+            orient='index', columns=['PC1', 'PC2', 'PC3']
+        )
+        pd.testing.assert_frame_equal(
+            self.tested_object_instance.pcoa.samples, expected_pcoa_samples,
+        )
+
+        expected_pcoa_proportions_explained = pd.Series(
+            [0.975623, 0.024377, 0], index=["PC1", "PC2", "PC3"],
+        )
+        pd.testing.assert_series_equal(
+            self.tested_object_instance.pcoa.proportion_explained, expected_pcoa_proportions_explained,
+        )
+
+    def test_label_with_proportion(self):
+        expected_object = "PC1 (97.56%)"
+        self.assertEqual(self.tested_object_instance._label_with_proportion("PC1"), expected_object)
 
     def test_unit_scale_with_scale_between0and1(self):
-        tested_object_instance = BrayCurtis(self.tested_object)
-
         tested_object = pd.DataFrame.from_dict(
             {
                 'species1': [-30],
@@ -271,13 +287,11 @@ class TestBrayCurtis(TestCase):
             columns=['PC1']
         )
         pd.testing.assert_frame_equal(
-            tested_object_instance._unit_scale(tested_object, 228, 0.456),
+            self.tested_object_instance._unit_scale(tested_object, 228, 0.456),
             expected_object
         )
 
     def test_unit_scale_with_scale_above1(self):
-        tested_object_instance = BrayCurtis(self.tested_object)
-
         tested_object = pd.DataFrame.from_dict(
             {
                 'species1': [-30],
@@ -306,13 +320,11 @@ class TestBrayCurtis(TestCase):
             columns=['PC1']
         )
         pd.testing.assert_frame_equal(
-            tested_object_instance._unit_scale(tested_object, 228, 22.8),
+            self.tested_object_instance._unit_scale(tested_object, 228, 22.8),
             expected_object
         )
 
     def test_scale_biplot(self):
-        tested_object_instance = BrayCurtis(self.tested_object)
-
         tested_features_df = pd.DataFrame.from_dict(
             {
                 ('genusA', 'species1'): [-30, 0],
@@ -358,8 +370,270 @@ class TestBrayCurtis(TestCase):
         expected_object.index = pd.MultiIndex.from_tuples(expected_object.index, names=('genus', 'species'))
 
         pd.testing.assert_frame_equal(
-            tested_object_instance._scale_biplot(tested_features_df, tested_samples_df),
+            self.tested_object_instance._scale_biplot(tested_features_df, tested_samples_df),
             expected_object
+        )
+
+    def test_map_loadings(self):
+        # already sorted
+        tested_pci = [-18, -12, -0.8, 0, 1.3, 4.5, 12, 38.2]
+        expected_object = ([6, 7], [0, 1])
+        self.assertTupleEqual(self.tested_object_instance._map_loadings(tested_pci, 2), expected_object)
+
+        # unsorted
+        tested_pci = [1.3, -0.8, 38.2, 0, 4.5, -18, -12, 12]
+        expected_object = ([7, 2], [5, 6])
+        self.assertTupleEqual(self.tested_object_instance._map_loadings(tested_pci, 2), expected_object)
+
+    def test_visualize_pcoa_scatter_1groupcol_nobiplot_noproportion(self):
+        metadata_df = pd.DataFrame.from_dict(
+            {
+                'sample1': ['M'],
+                'sample2': ['F'],
+                'sample3': ['F'],
+            },
+            orient='index', columns=['sex']
+        )
+
+        # PC1 vs PC2 (default)
+        # testing that it runs without error and checking a few variables
+        result_fig = self.tested_object_instance.visualize_pcoa(metadata_df, "sex", show=False)
+        self.assertEqual(result_fig.data[0]["type"], "scatter")
+        self.assertEqual(result_fig.layout["xaxis"]["title"]["text"], "PC1")
+        self.assertEqual(result_fig.layout["yaxis"]["title"]["text"], "PC2")
+
+        self.assertEqual(result_fig["data"][1]["name"], "F")
+        np.testing.assert_array_almost_equal(
+            result_fig["data"][1]["x"], [-0.43138279,  0.56791829], decimal=8)
+        np.testing.assert_array_almost_equal(
+            result_fig["data"][1]["y"], [-0.06428938, -0.02690815], decimal=8)
+
+        # PC2 vs PC3
+        result_fig = self.tested_object_instance.visualize_pcoa(metadata_df, "sex", x_pc=2, y_pc=3, show=False)
+        self.assertEqual(result_fig.layout["xaxis"]["title"]["text"], "PC2")
+        self.assertEqual(result_fig.layout["yaxis"]["title"]["text"], "PC3")
+
+        self.assertEqual(result_fig["data"][1]["name"], "F")
+        np.testing.assert_array_almost_equal(
+            result_fig["data"][1]["x"], [-0.06428938, -0.02690815], decimal=8)
+        np.testing.assert_array_equal(
+            result_fig["data"][1]["y"], [0, 0])
+
+    def test_visualize_pcoa_invalidmode_proportion(self):
+        # Checking that proportion work but also giving an invalid mode
+        # that will be changed to the default meaning 'scatter'
+        metadata_df = pd.DataFrame.from_dict(
+            {
+                'sample1': ['M'],
+                'sample2': ['F'],
+                'sample3': ['F'],
+            },
+            orient='index', columns=['sex']
+        )
+
+        with self.assertLogs("moonstone.analysis.diversity.beta", level="WARNING") as log:
+            result_fig = self.tested_object_instance.visualize_pcoa(
+                metadata_df, "sex", x_pc=1, y_pc=2,
+                mode="invalidmode", proportions=True,
+                show=False
+                )
+
+            # check warning
+            self.assertEqual(len(log.output), 1)
+            self.assertIn(
+                "WARNING:moonstone.analysis.diversity.beta:'invalidmode' not a available mode, \
+set to default (scatter).",
+                log.output,
+            )
+
+            # check invalid mode has been changed to 'scatter' the default
+            self.assertEqual(result_fig.data[0]["type"], "scatter")
+
+            # check proportions in title
+            self.assertEqual(result_fig.layout["xaxis"]["title"]["text"], "PC1 (97.56%)")
+            self.assertEqual(result_fig.layout["yaxis"]["title"]["text"], "PC2 (2.44%)")
+
+    def test_visualize_pcoa_scatter_2groupcol(self):
+        tested_object = pd.DataFrame.from_dict(
+            {
+                'species1': [4, 4, 0, 5, 3, 1, 0],
+                'species2': [1, 0, 2, 2, 1, 2, 2],
+                'species3': [0, 0, 0, 0, 1, 0, 0],
+                'species4': [0, 3, 0, 0, 2, 4, 1]
+            },
+            orient='index',
+            columns=['sample1', 'sample2', 'sample3', 'sample4', 'sample5', 'sample6', 'sample7']
+        )
+
+        metadata_df = pd.DataFrame.from_dict(
+            {
+                'sample1': ['M', 'A'],
+                'sample2': ['F', 'B'],
+                'sample3': ['F', 'B'],
+                'sample4': ['F', 'A'],
+                'sample5': ['M', 'B'],
+                'sample6': ['M', 'A'],
+                'sample7': ['F', 'A']
+            },
+            orient='index', columns=['sex', 'Group']
+        )
+        tested_object_instance = BrayCurtis(tested_object)
+
+        # testing that it runs without error and checking a few variables
+        result_fig = tested_object_instance.visualize_pcoa(
+            metadata_df, group_col='sex', group_col2='Group', x_pc=1, y_pc=2,
+            show=False)
+
+        # 2 "sex" * 2 "group" = 4 categories
+        self.assertEqual(len(result_fig.data), 4)
+        self.assertEqual(result_fig.data[0].marker.symbol, 0)
+        self.assertEqual(result_fig.data[0].marker.color, '#A63A50')
+        self.assertEqual(result_fig.data[0].name, "M - A")
+        np.testing.assert_array_almost_equal(
+            result_fig.data[0].x, [-0.24953334,  0.07681437], decimal=8)
+        np.testing.assert_array_almost_equal(
+            result_fig.data[0].y, [-0.26419982,  0.31054222], decimal=8)
+
+    def test_visualize_pcoa_scatter_biplot(self):
+        metadata_df = pd.DataFrame.from_dict(
+            {
+                'sample1': ['M'],
+                'sample2': ['F'],
+                'sample3': ['F'],
+            },
+            orient='index', columns=['sex']
+        )
+
+        # testing that it runs without error and checking a few variables
+        result_fig = self.tested_object_instance.visualize_pcoa(
+            metadata_df, "sex", x_pc=1, y_pc=2,
+            n_biplot_features=1,
+            show=False)
+
+        # x = pc1 axis explained most by:
+        #   * 'species1' in the negative direction
+        #   * 'species2' in the positive direction
+        # y = pc2 axis explained most by:
+        #   * 'species4' in the negative direction
+        #   * 'species1' in the positibe direction        # So 3 features shown * 2 (arrow + text) = 6 annotations
+        self.assertEqual(len(result_fig["layout"]["annotations"]), 6)
+
+        # checking one annotation
+        self.assertTrue(result_fig.layout.annotations[0].showarrow)
+        self.assertAlmostEqual(result_fig.layout.annotations[0].x, -0.4313827918950854, places=15)
+        self.assertAlmostEqual(result_fig.layout.annotations[0].y, 0.09119753638724884, places=15)
+        # see explanation for the use of the AlmostEqual in test_pcoa
+
+    def test_visualize_pcoa_scatter3d_1groupcol_nobiplot_noproportion(self):
+        metadata_df = pd.DataFrame.from_dict(
+            {
+                'sample1': ['M'],
+                'sample2': ['F'],
+                'sample3': ['F'],
+            },
+            orient='index', columns=['sex']
+        )
+
+        # PC1 vs PC2 vs PC3 (default)
+        # testing that it runs without error and checking a few variables
+        result_fig = self.tested_object_instance.visualize_pcoa(metadata_df, "sex", show=False, mode="scatter3d")
+        self.assertEqual(result_fig.data[0]["type"], "scatter3d")
+        self.assertEqual(result_fig.layout["scene"]["xaxis"]["title"]["text"], "PC1")
+        self.assertEqual(result_fig.layout["scene"]["yaxis"]["title"]["text"], "PC2")
+        self.assertEqual(result_fig.layout["scene"]["zaxis"]["title"]["text"], "PC3")
+
+        self.assertEqual(result_fig["data"][1]["name"], "F")
+        np.testing.assert_array_almost_equal(
+            result_fig["data"][1]["x"], [-0.43138279,  0.56791829], decimal=8)
+        np.testing.assert_array_almost_equal(
+            result_fig["data"][1]["y"], [-0.06428938, -0.02690815], decimal=8)
+        np.testing.assert_array_equal(
+            result_fig["data"][1]["z"], [0.0, 0.0])
+
+        # PC3 vs PC1 vs PC2
+        result_fig = self.tested_object_instance.visualize_pcoa(
+            metadata_df, "sex", show=False, mode="scatter3d",
+            x_pc=3, y_pc=1, z_pc=2
+        )
+        self.assertEqual(result_fig.layout["scene"]["xaxis"]["title"]["text"], "PC3")
+        self.assertEqual(result_fig.layout["scene"]["yaxis"]["title"]["text"], "PC1")
+        self.assertEqual(result_fig.layout["scene"]["zaxis"]["title"]["text"], "PC2")
+
+        np.testing.assert_array_equal(
+            result_fig["data"][1]["x"], [0.0, 0.0])
+
+    def test_visualize_pcoa_scatter3d_2groupcol_biplot_proportion(self):
+        tested_object = pd.DataFrame.from_dict(
+            {
+                'species1': [4, 4, 0, 5, 3, 1, 0],
+                'species2': [1, 0, 2, 2, 1, 2, 2],
+                'species3': [0, 0, 0, 0, 1, 0, 0],
+                'species4': [0, 3, 0, 0, 2, 4, 1]
+            },
+            orient='index',
+            columns=['sample1', 'sample2', 'sample3', 'sample4', 'sample5', 'sample6', 'sample7']
+        )
+
+        metadata_df = pd.DataFrame.from_dict(
+            {
+                'sample1': ['M', 'A'],
+                'sample2': ['F', 'B'],
+                'sample3': ['F', 'B'],
+                'sample4': ['F', 'A'],
+                'sample5': ['M', 'B'],
+                'sample6': ['M', 'A'],
+                'sample7': ['F', 'A']
+            },
+            orient='index', columns=['sex', 'Group']
+        )
+        tested_object_instance = BrayCurtis(tested_object)
+
+        # testing that it runs without error and checking a few variables
+        result_fig = tested_object_instance.visualize_pcoa(
+            metadata_df, group_col='sex', group_col2="Group",
+            mode='scatter3d', n_biplot_features=1, proportions=True,
+            show=False)
+
+        # x = pc1 axis explained most by:
+        #   * 'species1' in the negative direction
+        #   * 'species2' in the positive direction
+        # y = pc2 axis explained most by:
+        #   * 'species4' in the negative direction
+        #   * 'species1' in the positibe direction
+        # z = pc3 axis explained most by:
+        #   * ???
+        # So 4 features shown * 3 (line + cone + text) + 4 groups ("M - A", "M - B", "F - A", "F - B") = 16
+        self.assertEqual(len(result_fig.data), 16)
+        self.assertEqual(result_fig.layout.scene.xaxis.title.text, 'PC1 (67.37%)')
+        self.assertEqual(result_fig.layout.scene.yaxis.title.text, 'PC2 (26.23%)')
+        self.assertEqual(result_fig.layout.scene.zaxis.title.text, 'PC3 (5.59%)')
+
+
+class TestJaccard(TestCase):
+
+    def setUp(self):
+        self.tested_object = pd.DataFrame.from_dict(
+            {
+                'species1': [4, 4, 0],
+                'species2': [1, 0, 2],
+                'species3': [0, 0, 0],
+                'species4': [0, 3, 0]
+            },
+            orient='index', columns=['sample1', 'sample2', 'sample3']
+        )
+
+    def test_compute_beta_diversity(self):
+        tested_object_instance = Jaccard(self.tested_object)
+        expected_object = pd.DataFrame.from_dict(
+            {
+                'sample1': [0, 0.666667, 0.5],
+                'sample2': [0.666667, 0, 1],
+                'sample3': [0.5, 1, 0],
+            },
+            orient='index', columns=['sample1', 'sample2', 'sample3']
+        )
+        pd.testing.assert_frame_equal(
+            tested_object_instance.beta_diversity_df, expected_object,
         )
 
 

--- a/tests/plot/graphs/test_scatter.py
+++ b/tests/plot/graphs/test_scatter.py
@@ -1,0 +1,51 @@
+from unittest import TestCase
+
+import numpy as np
+import pandas as pd
+
+import plotly.graph_objects as go
+
+
+from moonstone.plot.graphs.scatter import GroupScatterGraph
+
+
+class TestGroupScatterGraph(TestCase):
+
+    def setUp(self):
+        self.test_df = pd.DataFrame.from_dict({
+            "sample1": [1.23, 4.8, "A", "y"],
+            "sample2": [-3.4, 0.87, "B", "n"],
+            "sample3": [0.99, -1.89, "A", "n"],
+            "sample4": [-2.22, -1.09, "C", "y"],
+        }, orient="index", columns=["var1", "var2", "group", "smoking"])
+        self.ins = GroupScatterGraph(self.test_df)
+
+    def test_plot_one_graph_1groupcol(self):
+        tested_fig = self.ins.plot_one_graph(
+            "var1", "var2", "group",
+            show=False
+        )
+        self.assertEqual(tested_fig["data"][0]["marker"]["color"], "#A63A50")
+        np.testing.assert_array_equal(
+            tested_fig["data"][0]["x"], np.array([1.23, 0.99]))
+        np.testing.assert_array_equal(
+            tested_fig["data"][0]["y"], np.array([4.8, -1.89]))
+        self.assertEqual(tested_fig["data"][0]["name"], "A")
+
+        self.assertEqual(tested_fig["data"][1]["marker"]["color"], "#FFBF00")
+        self.assertEqual(tested_fig["data"][2]["marker"]["color"], "#68ace8")
+
+    def test_plot_one_graph_2groupcol(self):
+        tested_fig = self.ins.plot_one_graph(
+            "var1", "var2", "group",
+            group_col2="smoking", show=False
+        )
+        self.assertEqual(tested_fig["data"][0]["marker"], go.scatter.Marker({'color': '#A63A50', 'symbol': 0}))
+        self.assertEqual(tested_fig["data"][1]["marker"], go.scatter.Marker({'color': '#FFBF00', 'symbol': 0}))
+        self.assertEqual(tested_fig["data"][2]["marker"], go.scatter.Marker({'color': '#68ace8', 'symbol': 0}))
+        self.assertEqual(tested_fig["data"][3]["marker"], go.scatter.Marker({'color': '#A63A50', 'symbol': 1}))
+
+    def test_symbol_scheme_under24(self):
+        tested_object = ["A", "B", "C"]
+        expected_object = {"A": 0, "B": 1, "C": 2}
+        np.testing.assert_array_equal(self.ins._symbol_scheme(tested_object), expected_object)

--- a/tests/plot/graphs/test_scatter.py
+++ b/tests/plot/graphs/test_scatter.py
@@ -23,7 +23,7 @@ class TestGroupScatterGraph(TestCase):
     def test_plot_one_graph_1groupcol(self):
         tested_fig = self.ins.plot_one_graph(
             "var1", "var2", "group",
-            show=False
+            show=False, plotting_options={"layout": {"height": 500, "width": 500}}
         )
         self.assertEqual(tested_fig["data"][0]["marker"]["color"], "#A63A50")
         np.testing.assert_array_equal(
@@ -45,7 +45,104 @@ class TestGroupScatterGraph(TestCase):
         self.assertEqual(tested_fig["data"][2]["marker"], go.scatter.Marker({'color': '#68ace8', 'symbol': 0}))
         self.assertEqual(tested_fig["data"][3]["marker"], go.scatter.Marker({'color': '#A63A50', 'symbol': 1}))
 
-    def test_symbol_scheme_under24(self):
+    def test_dictionary_marker_symbols(self):
+        expected_object = {
+            "circle": 0, "circle-open": 100, "circle-dot": 200, "circle-open-dot": 300, "square": 1,"square-open": 101,
+            "square-dot": 201, "square-open-dot": 301, "diamond": 2, "diamond-open": 102, "diamond-dot": 202,
+            "diamond-open-dot": 302, "cross": 3, "cross-open": 103, "cross-dot": 203, "cross-open-dot": 303, "x": 4,
+            "x-open": 104, "x-dot": 204, "x-open-dot": 304, "triangle-up": 5, "triangle-up-open": 105,
+            "triangle-up-dot": 205, "triangle-up-open-dot": 305, "triangle-down": 6, "triangle-down-open": 106,
+            "triangle-down-dot": 206, "triangle-down-open-dot": 306, "triangle-left": 7, "triangle-left-open": 107,
+            "triangle-left-dot": 207, "triangle-left-open-dot": 307, "triangle-right": 8, "triangle-right-open": 108,
+            "triangle-right-dot": 208, "triangle-right-open-dot": 308, "triangle-ne": 9, "triangle-ne-open": 109,
+            "triangle-ne-dot": 209, "triangle-ne-open-dot": 309, "triangle-se": 10, "triangle-se-open": 110,
+            "triangle-se-dot": 210, "triangle-se-open-dot": 310, "triangle-sw": 11, "triangle-sw-open": 111,
+            "triangle-sw-dot": 211, "triangle-sw-open-dot": 311, "triangle-nw": 12, "triangle-nw-open": 112,
+            "triangle-nw-dot": 212, "triangle-nw-open-dot": 312, "pentagon": 13, "pentagon-open": 113,
+            "pentagon-dot": 213, "pentagon-open-dot": 313, "hexagon": 14, "hexagon-open": 114, "hexagon-dot": 214,
+            "hexagon-open-dot": 314, "hexagon2": 15, "hexagon2-open": 115, "hexagon2-dot": 215,
+            "hexagon2-open-dot": 315, "octagon": 16, "octagon-open": 116, "octagon-dot": 216, "octagon-open-dot": 316,
+            "star": 17, "star-open": 117, "star-dot": 217, "star-open-dot": 317, "hexagram": 18, "hexagram-open": 118,
+            "hexagram-dot": 218, "hexagram-open-dot": 318, "star-triangle-up": 19, "star-triangle-up-open": 119,
+            "star-triangle-up-dot": 219, "star-triangle-up-open-dot": 319, "star-triangle-down": 20,
+            "star-triangle-down-open": 120, "star-triangle-down-dot": 220, "star-triangle-down-open-dot": 320,
+            "star-square": 21, "star-square-open": 121, "star-square-dot": 221, "star-square-open-dot": 321,
+            "star-diamond": 22, "star-diamond-open": 122, "star-diamond-dot": 222, "star-diamond-open-dot": 322,
+            "diamond-tall": 23, "diamond-tall-open": 123, "diamond-tall-dot": 223, "diamond-tall-open-dot": 323,
+            "diamond-wide": 24, "diamond-wide-open": 124, "diamond-wide-dot": 224, "diamond-wide-open-dot": 324,
+            "hourglass": 25, "hourglass-open": 125, "bowtie": 26, "bowtie-open": 126, "circle-cross": 27,
+            "circle-cross-open": 127, "circle-x": 28, "circle-x-open": 128, "square-cross": 29,
+            "square-cross-open": 129, "square-x": 30, "square-x-open": 130, "diamond-cross": 31,
+            "diamond-cross-open": 131, "diamond-x": 32, "diamond-x-open": 132, "cross-thin": 33,
+            "cross-thin-open": 133, "x-thin": 34, "x-thin-open": 134, "asterisk": 35, "asterisk-open": 135, "hash": 36,
+            "hash-open": 136, "hash-dot": 236, "hash-open-dot": 336, "y-up": 37, "y-up-open": 137, "y-down": 38,
+            "y-down-open": 138, "y-left": 39, "y-left-open": 139, "y-right": 40, "y-right-open": 140, "line-ew": 41,
+            "line-ew-open": 141, "line-ns": 42, "line-ns-open": 142, "line-ne": 43, "line-ne-open": 143, "line-nw": 44,
+            "line-nw-open": 144, "arrow-up": 45, "arrow-up-open": 145, "arrow-down": 46, "arrow-down-open": 146,
+            "arrow-left": 47, "arrow-left-open": 147, "arrow-right": 48, "arrow-right-open": 148, "arrow-bar-up": 49,
+            "arrow-bar-up-open": 149, "arrow-bar-down": 50, "arrow-bar-down-open": 150, "arrow-bar-left": 51,
+            "arrow-bar-left-open": 151, "arrow-bar-right": 52, "arrow-bar-right-open": 152, "arrow": 53,
+            "arrow-open": 153, "arrow-wide": 54, "arrow-wide-open": 154}
+        self.assertDictEqual(self.ins.dictionary_marker_symbols, expected_object)
+
+    def test_translating_forced_symbols(self):
+        tested_object = {"square", "103", 0}
+        expected_object = {0, 103, 1}
+        self.assertSetEqual(self.ins._translating_forced_symbols(tested_object), expected_object)
+
+    def test_translating_forced_symbols_invalidtext(self):
+        tested_object = {"square", "heart"}
+        with self.assertRaises(ValueError):
+            self.ins._translating_forced_symbols(tested_object)
+
+    def test_symbol_scheme_under72_woforcedsymbols(self):
         tested_object = ["A", "B", "C"]
         expected_object = {"A": 0, "B": 1, "C": 2}
+        np.testing.assert_array_equal(self.ins._symbol_scheme(tested_object), expected_object)
+
+    def test_symbol_scheme_under72_wforcedsymbols(self):
+        tested_object = ["A", "B", "C", "D", "E"]
+        forced_symbols = {
+            "A": "square",         # = 1 = "1"
+            "B": "103",            # = 103 = "cross-open"
+            "C": 0                 # = "0" = "circle"
+        }
+        expected_object = {
+            "D": 2, "E": 3,
+            "A": "square", "B": "103", "C": 0,
+            }
+        np.testing.assert_array_equal(
+            self.ins._symbol_scheme(tested_object, symbols=forced_symbols),
+            expected_object)
+
+    def test_symbol_scheme_over72(self):
+        tested_object = list(range(0, 73))
+        expected_object = {
+            0: 0, 1: 100, 2: 200, 3: 300, 4: 1, 5: 101, 6: 201, 7: 301, 8: 2, 9: 102, 10: 202, 11: 302, 12: 3, 13: 103,
+            14: 203, 15: 303, 16: 4, 17: 104, 18: 204, 19: 304, 20: 5, 21: 105, 22: 205, 23: 305, 24: 6, 25: 106,
+            26: 206, 27: 306, 28: 7, 29: 107, 30: 207, 31: 307, 32: 8, 33: 108, 34: 208, 35: 308, 36: 9, 37: 109,
+            38: 209, 39: 309, 40: 10, 41: 110, 42: 210, 43: 310, 44: 11, 45: 111, 46: 211, 47: 311, 48: 12, 49: 112,
+            50: 212, 51: 312, 52: 13, 53: 113, 54: 213, 55: 313, 56: 14, 57: 114, 58: 214, 59: 314, 60: 15, 61: 115,
+            62: 215, 63: 315, 64: 16, 65: 116, 66: 216, 67: 316, 68: 17, 69: 117, 70: 217, 71: 317, 72: 18}
+        np.testing.assert_array_equal(self.ins._symbol_scheme(tested_object), expected_object)
+
+    def test_symbol_scheme_over162(self):
+        tested_object = list(range(0, 163))
+        expected_object = {
+            0: 0, 1: 100, 2: 200, 3: 300, 4: 1, 5: 101, 6: 201, 7: 301, 8: 2, 9: 102, 10: 202, 11: 302, 12: 3, 13: 103,
+            14: 203, 15: 303, 16: 4, 17: 104, 18: 204, 19: 304, 20: 5, 21: 105, 22: 205, 23: 305, 24: 6, 25: 106,
+            26: 206, 27: 306, 28: 7, 29: 107, 30: 207, 31: 307, 32: 8, 33: 108, 34: 208, 35: 308, 36: 9, 37: 109,
+            38: 209, 39: 309, 40: 10, 41: 110, 42: 210, 43: 310, 44: 11, 45: 111, 46: 211, 47: 311, 48: 12, 49: 112,
+            50: 212, 51: 312, 52: 13, 53: 113, 54: 213, 55: 313, 56: 14, 57: 114, 58: 214, 59: 314, 60: 15, 61: 115,
+            62: 215, 63: 315, 64: 16, 65: 116, 66: 216, 67: 316, 68: 17, 69: 117, 70: 217, 71: 317, 72: 18, 73: 118,
+            74: 218, 75: 318, 76: 19, 77: 119, 78: 219, 79: 319, 80: 20, 81: 120, 82: 220, 83: 320, 84: 21, 85: 121,
+            86: 221, 87: 321, 88: 22, 89: 122, 90: 222, 91: 322, 92: 23, 93: 123, 94: 223, 95: 323, 96: 24, 97: 124,
+            98: 224, 99: 324, 100: 25, 101: 125, 102: 26, 103: 126, 104: 27, 105: 127, 106: 28, 107: 128, 108: 29,
+            109: 129, 110: 30, 111: 130, 112: 31, 113: 131, 114: 32, 115: 132, 116: 33, 117: 133, 118: 34, 119: 134,
+            120: 35, 121: 135, 122: 36, 123: 136, 124: 236, 125: 336, 126: 37, 127: 137, 128: 38, 129: 138, 130: 39,
+            131: 139, 132: 40, 133: 140, 134: 41, 135: 141, 136: 42, 137: 142, 138: 43, 139: 143, 140: 44, 141: 144,
+            142: 45, 143: 145, 144: 46, 145: 146, 146: 47, 147: 147, 148: 48, 149: 148, 150: 49, 151: 149, 152: 50,
+            153: 150, 154: 51, 155: 151, 156: 52, 157: 152, 158: 53, 159: 153, 160: 54, 161: 154,
+            162: 0  # -> repeating symbols because more groups than available symbols
+            }
         np.testing.assert_array_equal(self.ins._symbol_scheme(tested_object), expected_object)

--- a/tests/plot/graphs/test_scatter.py
+++ b/tests/plot/graphs/test_scatter.py
@@ -6,7 +6,7 @@ import pandas as pd
 import plotly.graph_objects as go
 
 
-from moonstone.plot.graphs.scatter import GroupScatterGraph
+from moonstone.plot.graphs.scatter import GroupScatterGraph, GroupScatter3DGraph
 
 
 class TestGroupScatterGraph(TestCase):
@@ -21,6 +21,7 @@ class TestGroupScatterGraph(TestCase):
         self.ins = GroupScatterGraph(self.test_df)
 
     def test_plot_one_graph_1groupcol(self):
+        # testing that it runs without error and checking a few variables
         tested_fig = self.ins.plot_one_graph(
             "var1", "var2", "group",
             show=False, plotting_options={"layout": {"height": 500, "width": 500}}
@@ -36,31 +37,32 @@ class TestGroupScatterGraph(TestCase):
         self.assertEqual(tested_fig["data"][2]["marker"]["color"], "#68ace8")
 
     def test_plot_one_graph_2groupcol(self):
+        # testing that it runs without error and checking a few variables
         tested_fig = self.ins.plot_one_graph(
             "var1", "var2", "group",
             group_col2="smoking", show=False
         )
         self.assertEqual(tested_fig["data"][0]["marker"], go.scatter.Marker({'color': '#A63A50', 'symbol': 0}))
-        self.assertEqual(tested_fig["data"][1]["marker"], go.scatter.Marker({'color': '#FFBF00', 'symbol': 0}))
-        self.assertEqual(tested_fig["data"][2]["marker"], go.scatter.Marker({'color': '#68ace8', 'symbol': 0}))
-        self.assertEqual(tested_fig["data"][3]["marker"], go.scatter.Marker({'color': '#A63A50', 'symbol': 1}))
+        self.assertEqual(tested_fig["data"][1]["marker"], go.scatter.Marker({'color': '#68ace8', 'symbol': 0}))
+        self.assertEqual(tested_fig["data"][2]["marker"], go.scatter.Marker({'color': '#A63A50', 'symbol': 1}))
+        self.assertEqual(tested_fig["data"][3]["marker"], go.scatter.Marker({'color': '#FFBF00', 'symbol': 1}))
 
     def test_dictionary_marker_symbols(self):
         expected_object = {
-            "circle": 0, "circle-open": 100, "circle-dot": 200, "circle-open-dot": 300, "square": 1,"square-open": 101,
-            "square-dot": 201, "square-open-dot": 301, "diamond": 2, "diamond-open": 102, "diamond-dot": 202,
-            "diamond-open-dot": 302, "cross": 3, "cross-open": 103, "cross-dot": 203, "cross-open-dot": 303, "x": 4,
-            "x-open": 104, "x-dot": 204, "x-open-dot": 304, "triangle-up": 5, "triangle-up-open": 105,
-            "triangle-up-dot": 205, "triangle-up-open-dot": 305, "triangle-down": 6, "triangle-down-open": 106,
-            "triangle-down-dot": 206, "triangle-down-open-dot": 306, "triangle-left": 7, "triangle-left-open": 107,
-            "triangle-left-dot": 207, "triangle-left-open-dot": 307, "triangle-right": 8, "triangle-right-open": 108,
-            "triangle-right-dot": 208, "triangle-right-open-dot": 308, "triangle-ne": 9, "triangle-ne-open": 109,
-            "triangle-ne-dot": 209, "triangle-ne-open-dot": 309, "triangle-se": 10, "triangle-se-open": 110,
-            "triangle-se-dot": 210, "triangle-se-open-dot": 310, "triangle-sw": 11, "triangle-sw-open": 111,
-            "triangle-sw-dot": 211, "triangle-sw-open-dot": 311, "triangle-nw": 12, "triangle-nw-open": 112,
-            "triangle-nw-dot": 212, "triangle-nw-open-dot": 312, "pentagon": 13, "pentagon-open": 113,
-            "pentagon-dot": 213, "pentagon-open-dot": 313, "hexagon": 14, "hexagon-open": 114, "hexagon-dot": 214,
-            "hexagon-open-dot": 314, "hexagon2": 15, "hexagon2-open": 115, "hexagon2-dot": 215,
+            "circle": 0, "circle-open": 100, "circle-dot": 200, "circle-open-dot": 300, "square": 1,
+            "square-open": 101, "square-dot": 201, "square-open-dot": 301, "diamond": 2, "diamond-open": 102,
+            "diamond-dot": 202, "diamond-open-dot": 302, "cross": 3, "cross-open": 103, "cross-dot": 203,
+            "cross-open-dot": 303, "x": 4, "x-open": 104, "x-dot": 204, "x-open-dot": 304, "triangle-up": 5,
+            "triangle-up-open": 105, "triangle-up-dot": 205, "triangle-up-open-dot": 305, "triangle-down": 6,
+            "triangle-down-open": 106, "triangle-down-dot": 206, "triangle-down-open-dot": 306, "triangle-left": 7,
+            "triangle-left-open": 107, "triangle-left-dot": 207, "triangle-left-open-dot": 307, "triangle-right": 8,
+            "triangle-right-open": 108, "triangle-right-dot": 208, "triangle-right-open-dot": 308, "triangle-ne": 9,
+            "triangle-ne-open": 109, "triangle-ne-dot": 209, "triangle-ne-open-dot": 309, "triangle-se": 10,
+            "triangle-se-open": 110, "triangle-se-dot": 210, "triangle-se-open-dot": 310, "triangle-sw": 11,
+            "triangle-sw-open": 111, "triangle-sw-dot": 211, "triangle-sw-open-dot": 311, "triangle-nw": 12,
+            "triangle-nw-open": 112, "triangle-nw-dot": 212, "triangle-nw-open-dot": 312, "pentagon": 13,
+            "pentagon-open": 113, "pentagon-dot": 213, "pentagon-open-dot": 313, "hexagon": 14, "hexagon-open": 114,
+            "hexagon-dot": 214, "hexagon-open-dot": 314, "hexagon2": 15, "hexagon2-open": 115, "hexagon2-dot": 215,
             "hexagon2-open-dot": 315, "octagon": 16, "octagon-open": 116, "octagon-dot": 216, "octagon-open-dot": 316,
             "star": 17, "star-open": 117, "star-dot": 217, "star-open-dot": 317, "hexagram": 18, "hexagram-open": 118,
             "hexagram-dot": 218, "hexagram-open-dot": 318, "star-triangle-up": 19, "star-triangle-up-open": 119,
@@ -146,3 +148,80 @@ class TestGroupScatterGraph(TestCase):
             162: 0  # -> repeating symbols because more groups than available symbols
             }
         np.testing.assert_array_equal(self.ins._symbol_scheme(tested_object), expected_object)
+
+    def test_symbol_scheme_nothingtodo(self):
+        tested_object = ["A", "B", "C"]
+        tested_symbols = {"A": 0, "B": 1, "C": 101}
+        expected_object = {"A": 0, "B": 1, "C": 101}
+        np.testing.assert_array_equal(self.ins._symbol_scheme(tested_object, tested_symbols), expected_object)
+
+
+class TestGroupScatter3DGraph(TestCase):
+
+    def setUp(self):
+        self.test_df = pd.DataFrame.from_dict({
+            "sample1": [1.23, 4.8, 0.34, "A", "y"],
+            "sample2": [-3.4, 0.87, 2.34, "B", "n"],
+            "sample3": [0.99, -1.89, -3.5, "A", "n"],
+            "sample4": [-2.22, -1.09, -0.019, "C", "y"],
+        }, orient="index", columns=["var1", "var2", "var3", "group", "smoking"])
+        self.ins = GroupScatter3DGraph(self.test_df)
+
+    def test_plot_one_graph_1groupcol(self):
+        tested_fig = self.ins.plot_one_graph(
+            "var1", "var2", "var3", "group",
+            show=False, plotting_options={"layout": {"height": 500, "width": 500}}
+        )
+        self.assertEqual(tested_fig["data"][0]["marker"]["color"], "#A63A50")
+        np.testing.assert_array_equal(
+            tested_fig["data"][0]["x"], np.array([1.23, 0.99]))
+        np.testing.assert_array_equal(
+            tested_fig["data"][0]["y"], np.array([4.8, -1.89]))
+        np.testing.assert_array_equal(
+            tested_fig["data"][0]["z"], np.array([0.34, -3.5]))
+        self.assertEqual(tested_fig["data"][0]["name"], "A")
+
+        self.assertEqual(tested_fig["data"][1]["marker"]["color"], "#FFBF00")
+        self.assertEqual(tested_fig["data"][2]["marker"]["color"], "#68ace8")
+
+    def test_plot_one_graph_2groupcol(self):
+        tested_fig = self.ins.plot_one_graph(
+            "var1", "var2", "var3", "group",
+            group_col2="smoking", show=False
+        )
+        self.assertEqual(tested_fig["data"][0]["marker"], go.scatter3d.Marker({'color': '#A63A50', 'symbol': 'circle'}))
+        self.assertEqual(tested_fig["data"][1]["marker"], go.scatter3d.Marker({'color': '#68ace8', 'symbol': 'circle'}))
+        self.assertEqual(tested_fig["data"][2]["marker"], go.scatter3d.Marker({'color': '#A63A50', 'symbol': 'cross'}))
+        self.assertEqual(tested_fig["data"][3]["marker"], go.scatter3d.Marker({'color': '#FFBF00', 'symbol': 'cross'}))
+
+    def test_symbol_scheme3d_under8_woforcedsymbols(self):
+        tested_object = ["A", "B", "C"]
+        expected_object = {"A": "circle", "B": "cross", "C": "diamond"}
+        np.testing.assert_array_equal(self.ins._symbol_scheme3d(tested_object), expected_object)
+
+    def test_symbol_scheme3d_under8_wforcedsymbols(self):
+        tested_object = ["A", "B", "C", "D", "E"]
+        forced_symbols = {
+            "A": "square",
+            "B": "diamond",
+        }
+        expected_object = {
+            "C": "circle", "D": "cross", "E": "circle-open",
+            "A": "square", "B": "diamond",
+            }
+        np.testing.assert_array_equal(
+            self.ins._symbol_scheme3d(tested_object, symbols=forced_symbols),
+            expected_object)
+
+    def test_symbol_scheme3d_over8(self):
+        tested_object = list(range(0, 9))
+        expected_object = {
+            0: 'circle', 1: 'cross', 2: 'diamond', 3: 'square', 4: 'circle-open', 5: 'diamond-open', 6: 'square-open',
+            7: 'x', 8: 'circle'}
+        np.testing.assert_array_equal(self.ins._symbol_scheme3d(tested_object), expected_object)
+
+    def test_symbol_scheme3d_nothingtodo(self):
+        tested_object = ["A", "B", "C"]
+        tested_symbols = {"A": 'circle', "B": 'cross', "C": 'square-open'}
+        expected_object = {"A": 'circle', "B": 'cross', "C": 'square-open'}
+        np.testing.assert_array_equal(self.ins._symbol_scheme3d(tested_object, tested_symbols), expected_object)

--- a/tests/plot/graphs/test_trendlines.py
+++ b/tests/plot/graphs/test_trendlines.py
@@ -145,7 +145,8 @@ class TestScatterTrendlines(TestCase):
             "species1", "species2", 2, log_x=False, log_y=False, nb_iter=100, nb_bootstraps=5, outliers="keep",
             show=False, random_state=11
         )
-        pd.testing.assert_series_equal(output["group_series"], self.expected_group_series)
+        expected_group_series_inv = (~self.expected_group_series.astype(bool)).astype(int)
+        pd.testing.assert_series_equal(output["group_series"], expected_group_series_inv)
 
     def test_plot_one_graph(self):
         # no bootstraps -> calls define_n_trendlines()

--- a/tests/plot/graphs/test_trendlines.py
+++ b/tests/plot/graphs/test_trendlines.py
@@ -145,8 +145,11 @@ class TestScatterTrendlines(TestCase):
             "species1", "species2", 2, log_x=False, log_y=False, nb_iter=100, nb_bootstraps=5, outliers="keep",
             show=False, random_state=11
         )
-        expected_group_series_inv = (~self.expected_group_series.astype(bool)).astype(int)
-        pd.testing.assert_series_equal(output["group_series"], expected_group_series_inv)
+        if output["group_series"].iloc[0] == self.expected_group_series.iloc[0]:
+            pd.testing.assert_series_equal(output["group_series"], self.expected_group_series)
+        else:
+            expected_group_series_inv = (~self.expected_group_series.astype(bool)).astype(int)
+            pd.testing.assert_series_equal(output["group_series"], expected_group_series_inv)
 
     def test_plot_one_graph(self):
         # no bootstraps -> calls define_n_trendlines()


### PR DESCRIPTION
## Description

* **Biplot** option to show the most explanatory features of the PCoA:
  - Define the number of biplot features **per direction** to show with the `n_biplot_features` argument.
    For example, in a 2D graph, if n_biplot_features=2, you will have:
    - the 2 features that explains the x axis in the negative direction the most
    - the 2 features that explains the x axis in the positive direction the most
    - the 2 features that explains the y axis in the negative direction the most
    - the 2 features that explains the y axis in the positive direction the most

Some features can explain both axis. So you will get between 4 and 8 features represented in the graph.

* Option to visualize a **second variable** of the metadata represented by different **symbols** (in addition to the first variable, group_col represented by colors):
  - Like for group_col, you can define the groups to show and in what order in the legend with the `groups2` argument
  - Like for group_col, you can specify the symbols used for certain groups by giving a dictionary to the `symbols` argument. The dictionary should have the group as key and the symbol as value. 
    - For the 2D graphs (mode="scatter"), the symbols can be expressed as their name ('circle') or as their number as int or string (0 or '0'). Full list of the 162 available symbols [here](https://plotly.com/python/marker-style/)
    - For the 3D graphs (mode="scatter3d"), only 8 different symbols are available and they must be defined with their names. List = ['circle', 'cross', 'diamond', 'square', 'circle-open', 'diamond-open', 'square-open', 'x']

If the number of groups exceeds the number of different symbols (162 for 2D graph and 8 for 3D graph), the symbols are repeated.

Example of the 2 new features:
![PCoA_biplot_2group_col_2D](https://github.com/user-attachments/assets/55114f5e-3bfc-484c-ab81-cc017a9880b8)
![PCoA_biplot_2group_col_3D](https://github.com/user-attachments/assets/0c698fc1-c328-47eb-b076-bafdadda43b0)



#### Changelogs

* argument `n_biplot_features` in the `visualize_pcoa` method of the `BetaDiversity` class to show the most explanatory features of the PCoA
* arguments `group_col2`, `groups2` and `symbols` in the `visualize_pcoa` method of the `BetaDiversity` class to visualize a second variable of the metadata represented by different symbols

#### Issue(s)

Fixes #106 

## Definition of Done

* [x]  New code is tested with unit tests
* [ ]  Documentation has been updated
* [ ]  Pull Request has been revised by a maintainer of the project
