### PR TITLE
Remove multiple identical warning in beta diversity

### DIFF
--- a/moonstone/analysis/diversity/base.py
+++ b/moonstone/analysis/diversity/base.py
@@ -16,6 +16,7 @@ from moonstone.plot.graphs.box import GroupBoxGraph, BoxGraph
 from moonstone.plot.graphs.heatmap import HeatmapGraph
 from moonstone.plot.graphs.histogram import Histogram
 from moonstone.plot.graphs.violin import GroupViolinGraph, ViolinGraph
+from moonstone.utils.log_messages import reset_warnings_decorator
 
 logger = logging.getLogger(__name__)
 
@@ -258,6 +259,7 @@ class DiversityBase(BaseModule, BaseDF, ABC):
         pval.index = pd.MultiIndex.from_tuples(pval.index, names=('Group1', 'Group2'))
         return pval
 
+    @reset_warnings_decorator
     def analyse_groups(
         self, metadata_df: pd.DataFrame, group_col: str, group_col2: str = None,
         mode: str = 'boxplot',
@@ -309,7 +311,6 @@ class DiversityBase(BaseModule, BaseDF, ABC):
                 filtered_metadata_df[group_col2].astype(str)
             )
             df = self._get_grouped_df(filtered_metadata_df[[group_col, group_col2, final_group_col]])
-
             if pval_to_compute == "all":
                 pval = self._run_statistical_test_groups(
                     df, final_group_col, stats_test, correction_method, structure_pval, sym

--- a/moonstone/analysis/diversity/beta.py
+++ b/moonstone/analysis/diversity/beta.py
@@ -13,6 +13,7 @@ from moonstone.analysis.diversity.base import (
     DiversityBase, PhylogeneticDiversityBase
 )
 from moonstone.plot.graphs.scatter import GroupScatterGraph, GroupScatter3DGraph
+from moonstone.utils.log_messages import warn_once, reset_warnings_decorator
 
 logger = logging.getLogger(__name__)
 
@@ -219,6 +220,7 @@ class BetaDiversity(DiversityBase, ABC):
         fig.update_layout(scene={"annotations": annotations})
         return fig
 
+    @reset_warnings_decorator
     def visualize_pcoa(
         self, metadata_df: pd.DataFrame, group_col: str, group_col2: str = None,
         mode: str = 'scatter',
@@ -342,7 +344,9 @@ class WeightedUniFrac(BetaDiversity, PhylogeneticDiversityBase):
             if not self.force_computation:
                 raise RuntimeError(f"INCOMPLETE TREE: missing {missing_ids}.")
             else:
-                logger.warning(f"INCOMPLETE TREE: missing {missing_ids}.\n\
+                #logger.warning(f"INCOMPLETE TREE: missing {missing_ids}.\n\
+#Computation of the Weighted UniFrac diversity using only the OTU IDs present in the Tree.")
+                warn_once(logger, f"INCOMPLETE TREE: missing {missing_ids}.\n\
 Computation of the Weighted UniFrac diversity using only the OTU IDs present in the Tree.")
                 otu_ids = list(set(otu_ids) - set(missing_ids))
 
@@ -365,7 +369,7 @@ class UnweightedUniFrac(BetaDiversity, PhylogeneticDiversityBase):
             if not self.force_computation:
                 raise RuntimeError(f"INCOMPLETE TREE: missing {missing_ids}.")
             else:
-                logger.warning(f"INCOMPLETE TREE: missing {missing_ids}.\n\
+                warn_once(logger, f"INCOMPLETE TREE: missing {missing_ids}.\n\
 Computation of the Unweighted UniFrac diversity using only the OTU IDs present in the Tree.")
                 otu_ids = list(set(otu_ids) - set(missing_ids))
 

--- a/moonstone/utils/log_messages.py
+++ b/moonstone/utils/log_messages.py
@@ -1,0 +1,24 @@
+from functools import lru_cache
+from logging import getLogger
+
+# Keep track of 10 different messages and then warn again
+@lru_cache(10)
+def warn_once(logger: getLogger, msg: str):
+    """"
+    To not repeat the same warning messages more than every n=10 differerent messages.
+    NB: only track messages passing through this function. 
+    
+    by Kound
+    src: https://stackoverflow.com/questions/31953272/logging-print-message-only-once
+    """
+    logger.warning(msg)
+
+def reset_warnings():
+    warn_once.cache_clear()
+
+def reset_warnings_decorator(func):
+    def wrapper(*args, **kwargs):
+        result = func(*args, **kwargs)
+        reset_warnings()  # Clear warning cache after function execution
+        return result
+    return wrapper

--- a/tests/analysis/diversity/test_beta.py
+++ b/tests/analysis/diversity/test_beta.py
@@ -387,40 +387,6 @@ class TestBrayCurtis(TestCase):
         expected_object = ([7, 2], [5, 6])
         self.assertTupleEqual(self.tested_object_instance._map_loadings(tested_pci, 2), expected_object)
 
-    def test_visualize_pcoa_scatter_1groupcol_nobiplot_noproportion(self):
-        metadata_df = pd.DataFrame.from_dict(
-            {
-                'sample1': ['M'],
-                'sample2': ['F'],
-                'sample3': ['F'],
-            },
-            orient='index', columns=['sex']
-        )
-
-        # PC1 vs PC2 (default)
-        # testing that it runs without error and checking a few variables
-        result_fig = self.tested_object_instance.visualize_pcoa(metadata_df, "sex", show=False)
-        self.assertEqual(result_fig.data[0]["type"], "scatter")
-        self.assertEqual(result_fig.layout["xaxis"]["title"]["text"], "PC1")
-        self.assertEqual(result_fig.layout["yaxis"]["title"]["text"], "PC2")
-
-        self.assertEqual(result_fig["data"][1]["name"], "F")
-        np.testing.assert_array_almost_equal(
-            result_fig["data"][1]["x"], [-0.43138279,  0.56791829], decimal=8)
-        np.testing.assert_array_almost_equal(
-            result_fig["data"][1]["y"], [-0.06428938, -0.02690815], decimal=8)
-
-        # PC2 vs PC3
-        result_fig = self.tested_object_instance.visualize_pcoa(metadata_df, "sex", x_pc=2, y_pc=3, show=False)
-        self.assertEqual(result_fig.layout["xaxis"]["title"]["text"], "PC2")
-        self.assertEqual(result_fig.layout["yaxis"]["title"]["text"], "PC3")
-
-        self.assertEqual(result_fig["data"][1]["name"], "F")
-        np.testing.assert_array_almost_equal(
-            result_fig["data"][1]["x"], [-0.06428938, -0.02690815], decimal=8)
-        np.testing.assert_array_equal(
-            result_fig["data"][1]["y"], [0, 0])
-
     def test_bi_plotly_multiindex(self):
         # Testing if it works with MultiIndex for the 2d version
         fig = go.Figure()
@@ -490,6 +456,40 @@ class TestBrayCurtis(TestCase):
         self.assertEqual(result_fig.data[4].text[0], 'species2')
         self.assertEqual(result_fig.data[7].text[0], 'species3')
         self.assertEqual(result_fig.data[10].text[0], 'species4')
+
+    def test_visualize_pcoa_scatter_1groupcol_nobiplot_noproportion(self):
+        metadata_df = pd.DataFrame.from_dict(
+            {
+                'sample1': ['M'],
+                'sample2': ['F'],
+                'sample3': ['F'],
+            },
+            orient='index', columns=['sex']
+        )
+
+        # PC1 vs PC2 (default)
+        # testing that it runs without error and checking a few variables
+        result_fig = self.tested_object_instance.visualize_pcoa(metadata_df, "sex", show=False)
+        self.assertEqual(result_fig.data[0]["type"], "scatter")
+        self.assertEqual(result_fig.layout["xaxis"]["title"]["text"], "PC1")
+        self.assertEqual(result_fig.layout["yaxis"]["title"]["text"], "PC2")
+
+        self.assertEqual(result_fig["data"][1]["name"], "F")
+        np.testing.assert_array_almost_equal(
+            result_fig["data"][1]["x"], [-0.43138279,  0.56791829], decimal=8)
+        np.testing.assert_array_almost_equal(
+            result_fig["data"][1]["y"], [-0.06428938, -0.02690815], decimal=8)
+
+        # PC2 vs PC3
+        result_fig = self.tested_object_instance.visualize_pcoa(metadata_df, "sex", x_pc=2, y_pc=3, show=False)
+        self.assertEqual(result_fig.layout["xaxis"]["title"]["text"], "PC2")
+        self.assertEqual(result_fig.layout["yaxis"]["title"]["text"], "PC3")
+
+        self.assertEqual(result_fig["data"][1]["name"], "F")
+        np.testing.assert_array_almost_equal(
+            result_fig["data"][1]["x"], [-0.06428938, -0.02690815], decimal=8)
+        np.testing.assert_array_equal(
+            result_fig["data"][1]["y"], [0, 0])
 
     def test_visualize_pcoa_invalidmode_proportion(self):
         # Checking that proportion work but also giving an invalid mode

--- a/tests/utils/test_dict_operations.py
+++ b/tests/utils/test_dict_operations.py
@@ -10,6 +10,7 @@ from moonstone.utils.dict_operations import (
 
 
 class TestMergeDict(TestCase):
+
     def test_simple_dicts(self):
         first_dict = {"a": 3, "b": 4}
         second_dict = {"a": 5, "c": 7}
@@ -72,6 +73,7 @@ class TestFilterDict(TestCase):
 
 
 class TestFlattenDict(TestCase):
+
     def test_flatten_dict(self):
         tested_dict = {'a': {'b': 1, 'c': 2}, 'd': 3, 'e': {'f': 4, 'g': {'h': 5}, 'i': 6}}
         expected_dict = {

--- a/tests/utils/test_log_messages.py
+++ b/tests/utils/test_log_messages.py
@@ -1,0 +1,76 @@
+import logging
+from unittest import TestCase
+
+from moonstone.utils.log_messages import warn_once, reset_warnings_decorator
+
+logger = logging.getLogger(__name__)
+
+class TestLogMessage(TestCase):
+
+    def test_warn_once_simple_case(self):
+        with self.assertLogs('tests.utils.test_log_messages', level='WARNING') as log:
+            warn_once(logger, "message to only print once.")
+            warn_once(logger, "message to only print once.")
+            self.assertEqual(len(log.output), 1)
+            self.assertIn("WARNING:tests.utils.test_log_messages:message to only print once.", log.output)
+
+    def test_warn_once_more_messages(self):
+        def testing_function():
+            warn_once(logger, "tracked warning message #1")
+            warn_once(logger, "tracked warning message #1")
+            logger.warning("other warning message")   # not tracked
+            logger.warning("not tracked")             # not tracked
+            for i in range(2, 11):
+                warn_once(logger, f"tracked warning message #{i}")
+            warn_once(logger, "tracked warning message #1") # not printed because in the 10 messages tracked
+            # But kick itself out to put itself back as most recent
+            # -> I don't like it but I should create a personalized tracker and I don't care enough
+
+            warn_once(logger, "other warning message")            # wasn't tracked so printed againt, but tracked now
+            warn_once(logger, "tracked warning message #2")       # printed because not in the storage anymore
+
+        with self.assertLogs('tests.utils.test_log_messages', level='WARNING') as log:
+            testing_function()
+            self.assertEqual(len(log.output), 14)
+            self.assertEqual(log.output[0], "WARNING:tests.utils.test_log_messages:tracked warning message #1")
+            self.assertEqual(log.output[1], "WARNING:tests.utils.test_log_messages:other warning message")
+            self.assertEqual(log.output[2], "WARNING:tests.utils.test_log_messages:not tracked")
+            self.assertEqual(log.output[3], "WARNING:tests.utils.test_log_messages:tracked warning message #2")
+            # ...
+            self.assertEqual(log.output[11], "WARNING:tests.utils.test_log_messages:tracked warning message #10")
+            self.assertEqual(log.output[12], "WARNING:tests.utils.test_log_messages:other warning message")
+            self.assertEqual(log.output[13], "WARNING:tests.utils.test_log_messages:tracked warning message #2")
+
+    def test_reset_warnings_decorator(self):
+        def testing_function_without_decorator(n):
+            warn_once(logger, "tracked warning message (w/o decorator)")
+            warn_once(logger, "tracked warning message (w/o decorator)")
+            warn_once(logger, f"different log message {n}")   # because otherwise during the second calling I get
+            # AssertionError: no logs of level WARNING or higher triggered on tests.utils.test_log_messages
+
+        with self.assertLogs('tests.utils.test_log_messages', level='WARNING') as log:
+            testing_function_without_decorator(1)
+            self.assertEqual(len(log.output), 2)
+            self.assertEqual(log.output[0], "WARNING:tests.utils.test_log_messages:tracked warning message (w/o decorator)")
+            self.assertEqual(log.output[1], "WARNING:tests.utils.test_log_messages:different log message 1")
+
+        with self.assertLogs('tests.utils.test_log_messages', level='WARNING') as log:
+            testing_function_without_decorator(2)
+            self.assertEqual(len(log.output), 1)     # cache not cleared so it doesn't print the first message
+            # but it print the second message that is unique
+            self.assertEqual(log.output[0], "WARNING:tests.utils.test_log_messages:different log message 2")
+
+        @reset_warnings_decorator
+        def testing_function_with_decorator():
+            warn_once(logger, "tracked warning message (w/ decorator)")
+            warn_once(logger, "tracked warning message (w/ decorator)")
+
+        with self.assertLogs('tests.utils.test_log_messages', level='WARNING') as log:
+            testing_function_with_decorator()
+            self.assertEqual(len(log.output), 1)
+            self.assertEqual(log.output[0], "WARNING:tests.utils.test_log_messages:tracked warning message (w/ decorator)")
+
+        with self.assertLogs('tests.utils.test_log_messages', level='WARNING') as log:
+            testing_function_with_decorator()
+            self.assertEqual(len(log.output), 1)
+            self.assertEqual(log.output[0], "WARNING:tests.utils.test_log_messages:tracked warning message (w/ decorator)")


### PR DESCRIPTION
## Description

<ins>Problem:</ins> cf #108

<ins>Solution:</ins> call a `warn_once` function (given by Kound on [stackoverflow](https://stackoverflow.com/questions/31953272/logging-print-message-only-once)) that track the last 10 messages and doesn't repeat the warning messages if it's in the last 10 messages registered.

NB: 
1. Only track messages printed with warn_once and not the other logger.warning.
2. If a message is in the most ancient of the last 10 messages stored, it won't be printed but will be stored again as the most recent.
3. To reset warnings, so that the warning messages are printed again when the function is rerun. The function need to be preceded by the decorator "@reset_warnings_decorator"

#### Changelogs

* `warn_once` , `reset_warnings` and `@reset_warnings_decorator` in **[new]** utils/log_messages.py

#### Issue(s)

Fixes #108

## Definition of Done

* [ ]  New code is tested with unit tests
* [ ]  Documentation has been updated
* [ ]  Pull Request has been revised by a maintainer of the project
