### PR TITLE
Fixing prevalence for higher taxonomical level than species

### DIFF
--- a/moonstone/analysis/differential_analysis.py
+++ b/moonstone/analysis/differential_analysis.py
@@ -53,8 +53,8 @@ class DifferentialAnalysis:
         pvalue = []
         variance_group1 = []
         variance_group2 = []
-        cat1 = self.full_table[self.full_table[feature] == self.full_table[feature][0]]
-        cat2 = self.full_table[self.full_table[feature] != self.full_table[feature][0]]
+        cat1 = self.full_table[self.full_table[feature] == self.full_table[feature].iloc[0]]
+        cat2 = self.full_table[self.full_table[feature] != self.full_table[feature].iloc[0]]
         for family in range(self.number_columns_to_skip, self.full_table.shape[1]):
             s1 = cat1[self.full_table.columns[family]].astype(float)
             s2 = cat2[self.full_table.columns[family]].astype(float)

--- a/moonstone/normalization/counts/geometric_mean.py
+++ b/moonstone/normalization/counts/geometric_mean.py
@@ -50,7 +50,7 @@ class GeometricMeanNormalization(BaseNormalization):
         return non_zero_dataf
 
     def log_df(self, df):
-        return df.applymap(lambda x: math.log(x, self.log_number))
+        return df.map(lambda x: math.log(x, self.log_number))
 
     @property
     def removed_zero_df(self):

--- a/moonstone/normalization/counts/geometric_mean.py
+++ b/moonstone/normalization/counts/geometric_mean.py
@@ -50,7 +50,7 @@ class GeometricMeanNormalization(BaseNormalization):
         return non_zero_dataf
 
     def log_df(self, df):
-        return df.map(lambda x: math.log(x, self.log_number))
+        return df.applymap(lambda x: math.log(x, self.log_number))
 
     @property
     def removed_zero_df(self):

--- a/moonstone/plot/counts.py
+++ b/moonstone/plot/counts.py
@@ -711,6 +711,8 @@ of the cohort"
             sep_series: Metadata used to order samples into subgroups (skipped by samples_order).
             sep_how: { None (default), 'color', 'labels' } Graphical way of showing the separation of the different
               subgroups (skipped if sep_series is empty/None).
+            orientation: orientation of the graph. {"v" (or "vertical")(default), "h-l" (or "horizontal-left"),
+              "h-r" (or "horizontal-right"}.
         """
         data_df, taxa_number = self._compute_relative_abundances_taxa_dataframe(
             taxa_level=taxa_level,

--- a/moonstone/plot/counts.py
+++ b/moonstone/plot/counts.py
@@ -14,7 +14,8 @@ from moonstone.utils.dict_operations import merge_dict
 from moonstone.utils.plot import (
     add_x_to_plotting_options,
     add_default_titles_to_plotting_options,
-    add_groups_annotations,
+    add_groups_annotations_vertical,
+    add_groups_annotations_horizontal
 )
 from moonstone.utils.pandas.series import SeriesBinning
 
@@ -690,6 +691,7 @@ of the cohort"
         color_df: pd.DataFrame = None,
         sep_series: pd.Series = None,
         sep_how: str = None,
+        orientation: str = "v",
         **kwargs,
     ) -> go.Figure:
         """
@@ -744,15 +746,27 @@ samples"
         if prevalence_threshold is not None:
             title += f" (present in at least {prevalence_threshold}% of samples)"
 
-        default_plotting_options = {
-            "layout": {
-                "title": title,
-                "xaxis_title": "Samples",
-                "yaxis_title": "Relative abundance",
-                "legend": {"traceorder": "normal"},
-                "legend_title_text": "species",
+        orientation = graph._valid_orientation_param(orientation, hplus=True)
+        if orientation == "v":
+            default_plotting_options = {
+                "layout": {
+                    "title": title,
+                    "xaxis_title": "Samples",
+                    "yaxis_title": "Relative abundance",
+                    "legend": {"traceorder": "normal"},
+                    "legend_title_text": "species",
+                }
             }
-        }
+        else:
+            default_plotting_options = {
+                "layout": {
+                    "title": title,
+                    "xaxis_title": "Relative abundance",
+                    "yaxis_title": "Samples",
+                    "legend": {"traceorder": "normal"},
+                    "legend_title_text": "species",
+                }
+            }
 
         plotting_options = merge_dict(kwargs.pop("plotting_options", {}), default_plotting_options)
 
@@ -760,15 +774,23 @@ samples"
             show = kwargs.pop("show", True)
             output_file = kwargs.pop("output_file", False)
             if color_df is None:
-                fig = graph.plot_one_graph(plotting_options=plotting_options, **kwargs, show=False)
+                fig = graph.plot_one_graph(plotting_options=plotting_options, orientation=orientation, **kwargs, show=False)
             else:
-                fig = graph.plot_complex_graph(color_df, plotting_options=plotting_options, **kwargs, show=False)
-            fig = add_groups_annotations(fig, x_coor, (0, 100, 104), subgps)
+                fig = graph.plot_complex_graph(color_df, plotting_options=plotting_options, orientation=orientation, **kwargs, show=False)
+
+            # adding separating labels
+            if orientation == "v":
+                fig = add_groups_annotations_vertical(fig, x_coor, (0, 100, 104), subgps)
+            elif orientation == "h-l":
+                fig = add_groups_annotations_horizontal(fig, (0, 100, 104), x_coor, subgps, 1, 2)
+            else:
+                fig = add_groups_annotations_horizontal(fig, (0, 100, 104), x_coor, subgps, 1, 1)
+
             graph._handle_output_plotly(fig, show, output_file)
         else:
             if color_df is None:
-                fig = graph.plot_one_graph(plotting_options=plotting_options, **kwargs)
+                fig = graph.plot_one_graph(plotting_options=plotting_options, orientation=orientation, **kwargs)
             else:
-                fig = graph.plot_complex_graph(color_df, plotting_options=plotting_options, **kwargs)
+                fig = graph.plot_complex_graph(color_df, plotting_options=plotting_options, orientation=orientation, **kwargs)
 
         return fig

--- a/moonstone/plot/graphs/bargraph.py
+++ b/moonstone/plot/graphs/bargraph.py
@@ -186,7 +186,8 @@ class MatrixBarGraph(BaseGraph):
         """
         Args:
             colors: Selected colors for a group.
-            orientation: orientation of the graph. {"v" (or "vertical")(default), "h-l" (or "horizontal-left"), "h-r" (or "horizontal-right"}.
+            orientation: orientation of the graph. {"v" (or "vertical")(default), "h-l" (or "horizontal-left"),
+              "h-r" (or "horizontal-right"}.
         """
         orientation = self._valid_orientation_param(orientation, hplus=True)
         
@@ -219,7 +220,8 @@ class MatrixBarGraph(BaseGraph):
         Args:
             metadata: pandas dataframe or series with the metadata relevant to show below/side-to-side to the bar graph.
             colors: Selected colors for a group in the bar graph part of the graph.
-            orientation: orientation of the bar graph. {"v" (or "vertical")(default), "h" (or "horizontal")}.
+            orientation: orientation of the graph. {"v" (or "vertical")(default), "h-l" (or "horizontal-left"),
+              "h-r" (or "horizontal-right"}.
         """
         # metadata = samples (row) * metadata (col)
         # data = species * samples
@@ -279,21 +281,35 @@ class MatrixBarGraph(BaseGraph):
             fig = self._gen_traces_metadata_legends_subplots(
                 fig, metadata, final_colors_metadata, orientation
             )
-
+        
         if "layout" in plotting_options.keys():
-            xaxis_title = plotting_options["layout"].pop("xaxis_title", "Samples")
-            if "legend" in plotting_options["layout"].keys():
-                plotting_options["layout"]["legend"].pop("traceorder", None)
+            xaxis_title = plotting_options["layout"].pop("xaxis_title", None)
+            fig.update_layout(
+                xaxis2=dict(  # xaxis of the 2nd subplot (to not have "samples" * 2)
+                    title_text=xaxis_title,
+                )
+            )
+        print("here6")
+        if orientation == "v":
+            fig.update_layout(
+                yaxis2=dict(showticklabels=False),  # yaxis of the 2nd subplot
+            )
         else:
-            xaxis_title = "Samples"
+            # horizontal
+            if orientation == "h-l":
+                fig.update_layout(
+                    xaxis1=dict(showticklabels=False),  # xaxis of the 1st subplot
+                )
+            else:
+                # h-r
+                fig.update_layout(
+                    xaxis2=dict(showticklabels=False),  # xaxis of the 2nd subplot
+                )
 
-        fig.update_layout(
-            xaxis2=dict(  # xaxis of the 2nd subplot (to not have "samples" * 2)
-                title_text=xaxis_title,
-            ),
-            yaxis2=dict(showticklabels=False),  # yaxis of the 2nd subplot
-            barmode="stack",
-        )
+        if "layout" in plotting_options.keys() and "legend" in plotting_options["layout"].keys():
+            plotting_options["layout"]["legend"].pop("traceorder", None)
+            # traceorder: "normal" given by `plot_sample_composition_most_abundant_taxa`
+        fig.update_layout(barmode="stack")
 
         if plotting_options is not None:
             fig = self._handle_plotting_options_plotly(fig, plotting_options)

--- a/moonstone/plot/graphs/bargraph.py
+++ b/moonstone/plot/graphs/bargraph.py
@@ -67,16 +67,34 @@ class MatrixBarGraph(BaseGraph):
     Represent a matrix using stacked Bar from plotly.
     """
 
-    def _add_chart(self, fig, final_colors, **kwargs) -> go.Figure:
+    def _add_chart(
+        self, fig, 
+        final_colors, orientation,
+        **kwargs
+    ) -> go.Figure:
         for col_name in self.data.index:
-            fig.add_trace(
-                go.Bar(
-                    name=col_name,
-                    x=self.data.columns,
-                    y=self.data.loc[col_name],
-                    marker_color=final_colors.get(col_name, None),
+            if orientation == "v":
+                fig.add_trace(
+                    go.Bar(
+                        name=col_name,
+                        x=self.data.columns,
+                        y=self.data.loc[col_name],
+                        orientation="v",
+                        marker_color=final_colors.get(col_name, None),
+                    )
                 )
-            )
+            else:
+                # horizontal
+                fig.add_trace(
+                    go.Bar(
+                        name=col_name,
+                        x=self.data.loc[col_name],
+                        y=self.data.columns,
+                        orientation="h",
+                        marker_color=final_colors.get(col_name, None),
+                    ),
+                    **kwargs
+                )
         return fig
 
     def _gen_traces_metadata_legends_subplot(
@@ -85,6 +103,7 @@ class MatrixBarGraph(BaseGraph):
         metadata_ser: pd.Series,
         name: str,
         final_colors_metadata: dict,
+        orientation: str
     ) -> go.Figure:
         lbls = list(metadata_ser.unique())
         lbls.sort(reverse=True)
@@ -102,26 +121,57 @@ class MatrixBarGraph(BaseGraph):
                     ]
                 )
             dfp["y"] = 1
-            fig.add_trace(
-                go.Bar(
-                    x=dfp.index,
-                    y=dfp["y"],
-                    name=lbl,
-                    marker=dict(color=final_colors_metadata[lbl]),
-                    legendgroup=name,
-                    legendgrouptitle_text=name,
-                ),
-                row=2,
-                col=1,
-            )
+            if orientation == "v":
+                fig.add_trace(
+                    go.Bar(
+                        x=dfp.index,
+                        y=dfp["y"],
+                        name=lbl,
+                        marker=dict(color=final_colors_metadata[lbl]),
+                        legendgroup=name,
+                        legendgrouptitle_text=name,
+                    ),
+                    row=2,
+                    col=1,
+                )
+            else:
+                # horizontal
+                if orientation == "h-l":
+                    fig.add_trace(
+                        go.Bar(
+                            x=dfp["y"],
+                            y=dfp.index,
+                            orientation="h",
+                            name=lbl,
+                            marker=dict(color=final_colors_metadata[lbl]),
+                            legendgroup=name,
+                            legendgrouptitle_text=name,
+                        ),
+                        row=1,
+                        col=1,
+                    )
+                else:
+                    fig.add_trace(
+                        go.Bar(
+                            x=dfp["y"],
+                            y=dfp.index,
+                            orientation="h",
+                            name=lbl,
+                            marker=dict(color=final_colors_metadata[lbl]),
+                            legendgroup=name,
+                            legendgrouptitle_text=name,
+                        ),
+                        row=1,
+                        col=2,
+                    )
         return fig
 
     def _gen_traces_metadata_legends_subplots(
-        self, fig: go.Figure, metadata_df: pd.DataFrame, final_colors_metadata: dict
+        self, fig: go.Figure, metadata_df: pd.DataFrame, final_colors_metadata: dict, orientation: str
     ) -> go.Figure:
         for cc in metadata_df.columns:
             fig = self._gen_traces_metadata_legends_subplot(
-                fig, metadata_df[cc], cc, final_colors_metadata
+                fig, metadata_df[cc], cc, final_colors_metadata, orientation
             )
         return fig
 
@@ -131,15 +181,21 @@ class MatrixBarGraph(BaseGraph):
         show: bool = True,
         output_file: Union[bool, str] = False,
         colors: dict = None,
+        orientation: str = "v",
     ) -> go.Figure:
         """
         Args:
-            colors: Selected colors for a group
+            colors: Selected colors for a group.
+            orientation: orientation of the graph. {"v" (or "vertical")(default), "h-l" (or "horizontal-left"), "h-r" (or "horizontal-right"}.
         """
+        orientation = self._valid_orientation_param(orientation, hplus=True)
+        
         final_colors = self._color_scheme_species(colors)
 
         fig = go.Figure()
-        fig = self._add_chart(fig, final_colors)
+        fig = self._add_chart(fig, final_colors, orientation)
+        if orientation == "h-r":
+            fig.update_xaxes(autorange="reversed")
 
         fig.update_layout(barmode="stack", legend_traceorder="reversed")
         if plotting_options is not None:
@@ -157,9 +213,18 @@ class MatrixBarGraph(BaseGraph):
         output_file: Union[bool, str] = False,
         colors: dict = None,
         colors_metadata: dict = None,
+        orientation: str = "v",
     ) -> go.Figure:
+        """
+        Args:
+            metadata: pandas dataframe or series with the metadata relevant to show below/side-to-side to the bar graph.
+            colors: Selected colors for a group in the bar graph part of the graph.
+            orientation: orientation of the bar graph. {"v" (or "vertical")(default), "h" (or "horizontal")}.
+        """
         # metadata = samples (row) * metadata (col)
         # data = species * samples
+
+        orientation = self._valid_orientation_param(orientation, hplus=True)
 
         final_colors = self._color_scheme_species(colors)  # attribute a color to each species
         final_colors_metadata = self._color_scheme_metadata(metadata, colors_metadata)
@@ -169,25 +234,50 @@ class MatrixBarGraph(BaseGraph):
         else:
             nrows = len(metadata.columns)
 
-        fig = make_subplots(
-            rows=2,
-            cols=1,
-            shared_xaxes=True,
-            vertical_spacing=0.02,
-            row_width=[0.02 * nrows, 1 - (0.02 * nrows)],
-        )
+        if orientation == "v":
+            fig = make_subplots(
+                rows=2,
+                cols=1,
+                shared_xaxes=True,
+                vertical_spacing=0.02,
+                start_cell='top-left',  # default
+                row_heights=[1 - (0.02 * nrows), 0.02 * nrows],
+            )
+        else:
+            # horizontal
+            if orientation == "h-l":
+                fig = make_subplots(
+                    rows=1,
+                    cols=2,
+                    shared_yaxes=True,
+                    horizontal_spacing=0.02,
+                    column_widths=[0.02 * nrows, 1 - (0.02 * nrows)],  # start from left
+                )
+            else:
+                fig = make_subplots(
+                    rows=1,
+                    cols=2,
+                    shared_yaxes=True,
+                    horizontal_spacing=0.02,
+                    column_widths=[1 - (0.02 * nrows), 0.02 * nrows],  # start from left
+                )
 
         # main graph
-        fig = self._add_chart(fig, final_colors)
+        if orientation == "h-l":
+            fig = self._add_chart(fig, final_colors, orientation, row=1, col=2)
+        else:
+            fig = self._add_chart(fig, final_colors, orientation)
+            if orientation == "h-r":
+                fig.update_xaxes(autorange="reversed")
 
         # metadata "legends" subplot.s
         if isinstance(metadata, pd.Series):
             fig = self._gen_traces_metadata_legends_subplot(
-                fig, metadata, metadata.name, final_colors_metadata
+                fig, metadata, metadata.name, final_colors_metadata, orientation
             )
         else:
             fig = self._gen_traces_metadata_legends_subplots(
-                fig, metadata, final_colors_metadata
+                fig, metadata, final_colors_metadata, orientation
             )
 
         if "layout" in plotting_options.keys():

--- a/moonstone/plot/graphs/bargraph.py
+++ b/moonstone/plot/graphs/bargraph.py
@@ -289,7 +289,7 @@ class MatrixBarGraph(BaseGraph):
                     title_text=xaxis_title,
                 )
             )
-        print("here6")
+
         if orientation == "v":
             fig.update_layout(
                 yaxis2=dict(showticklabels=False),  # yaxis of the 2nd subplot

--- a/moonstone/plot/graphs/base.py
+++ b/moonstone/plot/graphs/base.py
@@ -79,9 +79,23 @@ class BaseGraph(ABC):
             final_colors.update(**colors)
         return final_colors
 
-    def _valid_orientation_param(self, orientation: str) -> str:
+    def _valid_orientation_param(
+        self, orientation: str, hplus: bool = False,
+    ) -> str:
+        """
+        Args:
+            hplus: for an horizontal orientation can left or right be specified
+        """
         if orientation == "v" or orientation == "vertical":
             return "v"
+        if hplus:
+            o = orientation.split("-")
+            if o[0] == "h" or o[0] == "horizontal":
+                if len(o) == 1 or o[1] == "l" or o[1] == "left":
+                    # default behavior: "h" = "h-l" if hplus
+                    return "h-l"
+                elif o[1] == "r" or o[1] == "right":
+                    return "h-r"
         elif orientation == "h" or orientation == "horizontal":
             return "h"
         logger.warning("orientation=%s not valid, set to default (v).", orientation)

--- a/moonstone/plot/metadata.py
+++ b/moonstone/plot/metadata.py
@@ -106,7 +106,7 @@ class PlotMetadataStats:
             )
 
         graph = BarGraph(
-            pd.value_counts(self.metadata_df[sex_col]),
+            self.metadata_df[sex_col].value_counts(),
         )
         fig = graph.plot_one_graph(
             plotting_options=plotting_options,
@@ -158,7 +158,7 @@ class PlotMetadataStats:
             )
 
         graph = BarGraph(
-            pd.value_counts(self.metadata_df[column_name]),
+            self.metadata_df[column_name].value_counts(),
         )
         # if reset_xnames_dic is not None:
         #     bar_fig.reset_xnames(reset_xnames_dic)

--- a/moonstone/utils/pandas/series.py
+++ b/moonstone/utils/pandas/series.py
@@ -176,7 +176,7 @@ class SeriesBinning:
             binned_df = pd.cut(
                 self.data, bins=bins
             )  # put every items in the appropriate bin
-        data = pd.value_counts(binned_df)
+        data = binned_df.value_counts()
         data = data.reindex(binned_df.cat.categories)
         new_xnames = list(data.index.astype(str))
         tmp = new_xnames[0].split(",")

--- a/moonstone/utils/plot.py
+++ b/moonstone/utils/plot.py
@@ -65,13 +65,13 @@ def add_default_titles_to_plotting_options_3d(
     return plotting_options
 
 
-def add_groups_annotations(
+def add_groups_annotations_vertical(
     fig, x_coor: list, y_coor: tuple, groups: list,
     color_bg=["#FFFFFF", "#a7bcdb"],
 ) -> go.Figure:
     """
-    Add labels annotations, in the form of rectangles for the label with text annotations and a line separating the
-    groups going from the bottom of the rectangle to the bottom of the data.
+    Add labels annotations to a vertical bar graph, in the form of rectangles for the label with text annotations and a
+    line separating the groups going from the bottom of the rectangle to the bottom of the data.
 
     Args
         fig: The figure to which you want to add labels annotation above the data.
@@ -114,6 +114,69 @@ def add_groups_annotations(
                 x1=x_coor[i][2],
                 y1=y_coor[0],
                 line=dict(width=1, dash="solid", color="white"),
+            )
+        i += 1
+    return fig
+
+
+def add_groups_annotations_horizontal(
+    fig, x_coor: tuple, y_coor: list, groups: list,
+    row: int, col: int,
+    color_bg=["#FFFFFF", "#a7bcdb"],
+) -> go.Figure:
+    """
+    Add labels annotations to a horizontal bar graph, in the form of rectangles for the label with text annotations and
+    a line separating the groups going from the bottom of the rectangle to the bottom of the data.
+
+    Args
+        fig: The figure to which you want to add labels annotation above the data.
+        x_coor: List of x coordinates triplet [(x start of background, x of text annotation, x end of background)].
+        y_coor: Tuple of 3 y coordinates : (y bottom of line, y bottom of rectangle, y top of rectangle)
+        groups: List of groups' name, should be in the same order as x_coor.
+    """
+    if col == 1:
+        txtangle = -90
+    else:
+        txtangle = 90
+    i = 0
+    x_med = (x_coor[1] + x_coor[2])/2
+    n_cbg = len(color_bg)
+    while i < len(groups):
+        # adding background color
+        fig.add_shape(
+            type="rect",
+            x0=x_coor[1],
+            y0=y_coor[i][0],
+            x1=x_coor[2],
+            y1=y_coor[i][2],
+            line=dict(
+                width=0,
+            ),
+            fillcolor=color_bg[i % n_cbg],
+            row=row, col=col
+        )
+        # adding text annotation (group name)
+        fig.add_annotation(
+            x=x_med,
+            y=y_coor[i][1],
+            xref="x",
+            yref="y",
+            text=groups[i],
+            textangle=txtangle,
+            showarrow=False,
+            font=dict(family="Arial", size=14),
+            row=row, col=col
+        )
+        if i < (len(groups) - 1):
+            # adding line separating groups
+            fig.add_shape(
+                type="line",
+                x0=x_coor[1],
+                y0=y_coor[i][2],
+                x1=x_coor[0],
+                y1=y_coor[i][2],
+                line=dict(width=1, dash="solid", color="white"),
+                row=row, col=col
             )
         i += 1
     return fig

--- a/moonstone/utils/plot.py
+++ b/moonstone/utils/plot.py
@@ -76,14 +76,14 @@ def add_groups_annotations_vertical(
     Args
         fig: The figure to which you want to add labels annotation above the data.
         x_coor: List of x coordinates triplet [(x start of background, x of text annotation, x end of background)].
-        y_coor: Tuple of 3 y coordinates : (y bottom of line, y bottom of rectangle, y top of rectangle)
+        y_coor: Tuple of 3 y coordinates : (y bottom of line, y bottom of rectangle, y top of rectangle).
         groups: List of groups' name, should be in the same order as x_coor.
     """
     i = 0
     y_med = (y_coor[1] + y_coor[2])/2
     n_cbg = len(color_bg)
     while i < len(groups):
-        # adding background color
+        # adding rectangle that will contain the text
         fig.add_shape(
             type="rect",
             x0=x_coor[i][0],
@@ -93,7 +93,7 @@ def add_groups_annotations_vertical(
             line=dict(
                 width=0,
             ),
-            fillcolor=color_bg[i % n_cbg],
+            fillcolor=color_bg[i % n_cbg],  # alternating the color of the rectangle for visibility
         )
         # adding text annotation (group name)
         fig.add_annotation(
@@ -127,12 +127,15 @@ def add_groups_annotations_horizontal(
     """
     Add labels annotations to a horizontal bar graph, in the form of rectangles for the label with text annotations and
     a line separating the groups going from the bottom of the rectangle to the bottom of the data.
+    when orientation="horizontal-right", bottom of the data means right of the bar graph and top means left.
+    when orientation="horizontal-left", bottom of the data means left of the bar graph and top means right.
+    Please read the arguments with that in mind.
 
     Args
         fig: The figure to which you want to add labels annotation above the data.
-        x_coor: List of x coordinates triplet [(x start of background, x of text annotation, x end of background)].
-        y_coor: Tuple of 3 y coordinates : (y bottom of line, y bottom of rectangle, y top of rectangle)
-        groups: List of groups' name, should be in the same order as x_coor.
+        x_coor: Tuple of 3 x coordinates : (x bottom of line, x bottom of rectangle, x top of rectangle).
+        y_coor: List of y coordinates triplet [(y start of background, y of text annotation, y end of background)].
+        groups: List of groups' name, should be in the same order as y_coor.
     """
     if col == 1:
         txtangle = -90
@@ -142,7 +145,7 @@ def add_groups_annotations_horizontal(
     x_med = (x_coor[1] + x_coor[2])/2
     n_cbg = len(color_bg)
     while i < len(groups):
-        # adding background color
+        # adding rectangle that will contain the text
         fig.add_shape(
             type="rect",
             x0=x_coor[1],
@@ -152,7 +155,7 @@ def add_groups_annotations_horizontal(
             line=dict(
                 width=0,
             ),
-            fillcolor=color_bg[i % n_cbg],
+            fillcolor=color_bg[i % n_cbg],  # alternating the color of the rectangle for visibility
             row=row, col=col
         )
         # adding text annotation (group name)

--- a/moonstone/utils/taxonomy.py
+++ b/moonstone/utils/taxonomy.py
@@ -41,7 +41,7 @@ class TaxonomyCountsBase():
         value            Bacteria Bacteroidetes ... Tannerellaceae Tannerellaceae (family)
         """
         taxa_df_with_rank = taxa_df.apply(lambda x: x + " ({})".format(x.name))
-        taxa_df_with_rank_filled_none = taxa_df_with_rank.fillna(method='ffill', axis=1)
+        taxa_df_with_rank_filled_none = taxa_df_with_rank.ffill(axis=1)
         taxa_df_filled_none = taxa_df.combine_first(taxa_df_with_rank_filled_none)
         return taxa_df_filled_none
 
@@ -58,7 +58,7 @@ class TaxonomyCountsBase():
             else:
                 return '_'.join(genus_and_species)
 
-        taxa_df['species'] = taxa_df[['genus', 'species']].apply(lambda x: join_genus_species(x), axis=1)
+        taxa_df['species'] = taxa_df[['genus', 'species']].apply(lambda x: join_genus_species(list(x)), axis=1)
         return taxa_df
 
     def split_taxa_fill_none(self, df: pd.DataFrame, sep: str = ";",  taxo_prefix: str = "__",
@@ -83,7 +83,7 @@ class TaxonomyCountsBase():
             self.rank_level = len(taxa_columns.columns)
 
         taxa_columns.columns = self.taxonomical_names[:self.rank_level]
-        taxa_columns = taxa_columns.applymap(lambda x: remove_taxo_prefix(x))
+        taxa_columns = taxa_columns.map(lambda x: remove_taxo_prefix(x))
         if terms_to_remove is not None:
             taxa_columns = taxa_columns.replace(terms_to_remove, None)
         if merge_genus_species:

--- a/moonstone/utils/taxonomy.py
+++ b/moonstone/utils/taxonomy.py
@@ -83,7 +83,7 @@ class TaxonomyCountsBase():
             self.rank_level = len(taxa_columns.columns)
 
         taxa_columns.columns = self.taxonomical_names[:self.rank_level]
-        taxa_columns = taxa_columns.map(lambda x: remove_taxo_prefix(x))
+        taxa_columns = taxa_columns.applymap(lambda x: remove_taxo_prefix(x))
         if terms_to_remove is not None:
             taxa_columns = taxa_columns.replace(terms_to_remove, None)
         if merge_genus_species:

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ msgpack>=1.0.0
     # via cachecontrol
 natsort>=7.0.1
     # via scikit-bio
-numpy>=1.26.4
+numpy==1.26.4
     # via
     #   hdmedians
     #   matplotlib

--- a/tests/parsers/counts/taxonomy/test_base.py
+++ b/tests/parsers/counts/taxonomy/test_base.py
@@ -13,17 +13,21 @@ class TestTaxonomyCountsBase(TestCase):
     def test_fill_none(self):
         taxa_df = pd.DataFrame(
             [
-                ['Bacteria', 'Bacteroidetes'],
-                ['Bacteria', None]
+                ['Bacteria', 'Bacillota', 'Bacilli'],
+                ['Bacteria', None, None],
+                ['Bacteria', 'Firmicutes', None],
+                ['Bacteria', None, 'Deltaproteobacteria']
             ],
-            columns=['kingdom', 'phylum']
+            columns=['kingdom', 'phylum', 'class']
         )
         expected_df = pd.DataFrame(
             [
-                ['Bacteria', 'Bacteroidetes'],
-                ['Bacteria', 'Bacteria (kingdom)']
+                ['Bacteria', 'Bacillota', 'Bacilli'],
+                ['Bacteria', 'Bacteria (kingdom)', 'Bacteria (kingdom)'],
+                ['Bacteria', 'Firmicutes', 'Firmicutes (phylum)'],
+                ['Bacteria', 'Bacteria (kingdom)', 'Deltaproteobacteria']
             ],
-            columns=['kingdom', 'phylum']
+            columns=['kingdom', 'phylum', 'class']
         )
         tested_df = self.taxonomy_instance._fill_none(taxa_df)
         pd.testing.assert_frame_equal(tested_df, expected_df)

--- a/tests/plot/test_counts.py
+++ b/tests/plot/test_counts.py
@@ -43,6 +43,7 @@ class TestPlotTaxonomyCounts(TestCase):
                     4.2,
                     0.0,
                     2.0,
+                    0.0
                 ],
                 [
                     "Bacteria",
@@ -56,6 +57,7 @@ class TestPlotTaxonomyCounts(TestCase):
                     16.0,
                     8.0,
                     9.0,
+                    1.0,
                 ],
                 [
                     "Bacteria",
@@ -69,6 +71,7 @@ class TestPlotTaxonomyCounts(TestCase):
                     0.4,
                     0.0,
                     3.0,
+                    0.0
                 ],
                 [
                     "Bacteria",
@@ -82,6 +85,7 @@ class TestPlotTaxonomyCounts(TestCase):
                     0.2,
                     0.7,
                     0.1,
+                    0.7,
                 ],
                 [
                     "Bacteria",
@@ -95,6 +99,7 @@ class TestPlotTaxonomyCounts(TestCase):
                     1.2,
                     0.0,
                     2.3,
+                    0.0
                 ],
             ],
             columns=[
@@ -109,6 +114,7 @@ class TestPlotTaxonomyCounts(TestCase):
                 "SAMPLE_2",
                 "SAMPLE_3",
                 "SAMPLE_4",
+                "SAMPLE_5"
             ],
         )
         self.tested_object = self.tested_object.set_index(
@@ -140,9 +146,9 @@ class TestPlotTaxonomyCounts(TestCase):
         # -------------
         df_add = pd.DataFrame(
             data={
-                "SAMPLE_5": [0.0, 21.0, 1.4, 3.1, 0.0],
                 "SAMPLE_6": [1.0, 12.0, 0.0, 0.0, 0.0],
                 "SAMPLE_7": [0.0, 8.9, 0.0, 0.0, 1.3],
+                "SAMPLE_8": [0.0, 21.0, 1.4, 3.1, 0.0],
             },
             index=self.tested_object.index,
         )
@@ -158,6 +164,7 @@ class TestPlotTaxonomyCounts(TestCase):
                     "SAMPLE_5": "no",
                     "SAMPLE_6": "no",
                     "SAMPLE_7": "yes",
+                    "SAMPLE_8": "no",
                 },
                 "GROUP": {
                     "SAMPLE_1": "A",
@@ -167,6 +174,7 @@ class TestPlotTaxonomyCounts(TestCase):
                     "SAMPLE_5": "C",
                     "SAMPLE_6": "B",
                     "SAMPLE_7": "A",
+                    "SAMPLE_8": "C",
                 },
             }
         )
@@ -186,6 +194,7 @@ class TestPlotTaxonomyCounts(TestCase):
                     19.090909,
                     0.0,
                     12.195122,
+                    0.0
                 ],
                 [
                     "Bacteria",
@@ -199,6 +208,7 @@ class TestPlotTaxonomyCounts(TestCase):
                     72.727273,
                     91.954023,
                     54.878049,
+                    58.8235529
                 ],
                 [
                     "Bacteria",
@@ -212,6 +222,7 @@ class TestPlotTaxonomyCounts(TestCase):
                     1.818182,
                     0.0,
                     18.292683,
+                    0.0
                 ],
                 [
                     "Bacteria",
@@ -225,6 +236,7 @@ class TestPlotTaxonomyCounts(TestCase):
                     0.909091,
                     8.045977,
                     0.609756,
+                    41.176471
                 ],
                 [
                     "Bacteria",
@@ -238,6 +250,7 @@ class TestPlotTaxonomyCounts(TestCase):
                     5.454545,
                     0.0,
                     14.024390,
+                    0.0
                 ],
             ],
             columns=[
@@ -252,6 +265,7 @@ class TestPlotTaxonomyCounts(TestCase):
                 "SAMPLE_2",
                 "SAMPLE_3",
                 "SAMPLE_4",
+                "SAMPLE_5"
             ],
         )
         expected_df = expected_df.set_index(
@@ -265,10 +279,10 @@ class TestPlotTaxonomyCounts(TestCase):
 
     def test_prevalence_series_species(self):
         expected_ser = pd.Series({
-            "Actinobaculum_massiliense": 50.0,
-            "Lactobacillus (genus)": 75.0,
-            "Streptococcus (genus)": 75.0,
-            "Streptococcus_salivarius": 75.0,
+            "Actinobaculum_massiliense": 40.0,
+            "Lactobacillus (genus)": 80.0,
+            "Streptococcus (genus)": 60.0,
+            "Streptococcus_salivarius": 60.0,
             "Streptococcus_thermophilus": 100.0,
             })
         expected_ser.index.name = "species"
@@ -443,15 +457,15 @@ class TestPlotTaxonomyCounts(TestCase):
         taxa_level = "species"
         expected_df = pd.DataFrame(
             [
-                [61.111111, 5.454545, 0.0, 14.02439],
+                [14.814815, 0.909091, 8.045977, 0.609756, 41.176471],
             ],
-            index=["Streptococcus_salivarius"],
-            columns=["SAMPLE_1", "SAMPLE_2", "SAMPLE_3", "SAMPLE_4"],
+            index=["Streptococcus_thermophilus"],
+            columns=["SAMPLE_1", "SAMPLE_2", "SAMPLE_3", "SAMPLE_4", "SAMPLE_5"],
         )
         expected_df.columns.name = "sample"
         expected_df.index.name = taxa_level
 
-        expected_ser = pd.Series({"Streptococcus_salivarius": 20.14751170238975})
+        expected_ser = pd.Series({"Streptococcus_thermophilus": 13.111222})
         expected_ser.index.name = taxa_level
 
         (
@@ -461,9 +475,9 @@ class TestPlotTaxonomyCounts(TestCase):
         ) = self.tested_instance._compute_relative_abundances_taxa_dataframe(
             taxa_level=taxa_level,
             taxa_number=2,  # skipped
-            average_relative_abundance_threshold=7.0,
-            higher_classification=False,
-            prevalence_threshold=60,
+            average_relative_abundance_threshold=7.0,   # remove A. massiliense
+            higher_classification=False,                # remove Streptococcus (genus) + Lactobacillus (genus)
+            prevalence_threshold=70,                    # remove (A. m. + Streptococcus (genus)) + S. salivarius
             ascending=False,
         )
 
@@ -475,17 +489,17 @@ class TestPlotTaxonomyCounts(TestCase):
         taxa_level = "genus"
         expected_df = pd.DataFrame(
             [
-                [0.0, 72.727273, 91.954023, 54.878049],
-                [100.0, 8.181818, 8.045977, 32.926829],
+                [0.0, 72.727273, 91.954023, 54.878049, 58.823529],
+                [100.0, 8.181818, 8.045977, 32.926829, 41.176471],
             ],
             index=["Lactobacillus", "Streptococcus"],
-            columns=["SAMPLE_1", "SAMPLE_2", "SAMPLE_3", "SAMPLE_4"],
+            columns=["SAMPLE_1", "SAMPLE_2", "SAMPLE_3", "SAMPLE_4", "SAMPLE_5"],
         )
         expected_df.columns.name = "sample"
         expected_df.index.name = taxa_level
 
         expected_ser = pd.Series(
-            {"Lactobacillus": 54.889836124066576, "Streptococcus": 37.28865611540128}
+            {"Lactobacillus": 55.676575, "Streptococcus": 38.066219}
         )
         expected_ser.index.name = taxa_level
 
@@ -576,9 +590,9 @@ class TestPlotTaxonomyCounts(TestCase):
         fig = self.tested_instance._plot_most_abundant_taxa_bargraph(
             taxa_number=3, prevalence_threshold=None, ascending=False, show=False
         )
-        expected_x = (11.04623470477129, 20.14751170238975, 54.889836124066576)
+        expected_x = (13.111221884239251, 16.1180093619118, 55.6765747816062)
         expected_y = (
-            "<i>Streptococcus</i> (genus)",
+            "<i>Streptococcus thermophilus</i>",
             "<i>Streptococcus salivarius</i>",
             "<i>Lactobacillus</i> (genus)",
         )
@@ -592,11 +606,11 @@ class TestPlotTaxonomyCounts(TestCase):
         fig = self.tested_instance._plot_most_abundant_taxa_bargraph(
             taxa_number=3, ascending=True, show=False
         )
-        expected_x = (54.889836124066576, 20.14751170238975, 11.04623470477129)
+        expected_x = (55.6765747816062, 16.1180093619118, 13.111221884239251)
         expected_y = (
             "<i>Lactobacillus</i> (genus)",
             "<i>Streptococcus salivarius</i>",
-            "<i>Streptococcus</i> (genus)",
+            "<i>Streptococcus thermophilus</i>",
         )
 
         self.assertTupleEqual(fig["data"][0]["x"], expected_x)
@@ -604,16 +618,16 @@ class TestPlotTaxonomyCounts(TestCase):
 
     def test_plot_most_abundant_taxa_bargraph_prevalence_threshold(self):
         fig = self.tested_instance._plot_most_abundant_taxa_bargraph(
-            taxa_number=3, prevalence_threshold=80, show=False
+            taxa_number=3, prevalence_threshold=90, show=False
         )
-        expected_x = tuple([6.0949097082402375])
+        expected_x = tuple([13.111221884239251])
         expected_y = tuple(["<i>Streptococcus thermophilus</i>"])
 
         self.assertTupleEqual(fig["data"][0]["x"], expected_x)
         self.assertTupleEqual(fig["data"][0]["y"], expected_y)
         self.assertEqual(
             fig["layout"]["title"]["text"],
-            "1 most abundant species (present in at least 80% of samples)",
+            "1 most abundant species (present in at least 90% of samples)",
         )
 
     def test_plot_most_abundant_taxa_boxplot(self):
@@ -621,15 +635,17 @@ class TestPlotTaxonomyCounts(TestCase):
             "abundant", "boxplot", taxa_number=2, show=False
         )
 
-        expected_x_Ss = [61.11111111, 5.45454545, 0.0, 14.02439024]
+        expected_x_Ss = [61.11111111, 5.45454545, 0.0, 14.02439024, 0.0]
         expected_y_Ss = [
             "<i>Streptococcus salivarius</i>",
             "<i>Streptococcus salivarius</i>",
             "<i>Streptococcus salivarius</i>",
             "<i>Streptococcus salivarius</i>",
+            "<i>Streptococcus salivarius</i>",
         ]
-        expected_x_L = [0.0, 72.72727273, 91.95402299, 54.87804878]
+        expected_x_L = [0.0, 72.72727273, 91.95402299, 54.87804878, 58.82352941]
         expected_y_L = [
+            "<i>Lactobacillus</i> (genus)",
             "<i>Lactobacillus</i> (genus)",
             "<i>Lactobacillus</i> (genus)",
             "<i>Lactobacillus</i> (genus)",
@@ -651,12 +667,13 @@ of the cohort",
             "abundant",
             "violin",
             taxa_number=2,
-            threshold_on_other_variable=80,
+            threshold_on_other_variable=90,     # only keep S. thermophilus
             show=False,
         )
 
-        expected_x_St = [14.81481481, 0.90909091, 8.04597701, 0.6097561]
+        expected_x_St = [14.81481481, 0.90909091, 8.04597701, 0.6097561, 41.176470588]
         expected_y_St = [
+            "<i>Streptococcus thermophilus</i>",
             "<i>Streptococcus thermophilus</i>",
             "<i>Streptococcus thermophilus</i>",
             "<i>Streptococcus thermophilus</i>",
@@ -668,7 +685,7 @@ of the cohort",
         self.assertEqual(
             fig["layout"]["title"]["text"],
             "Relative abundance of the 1 most abundant microbial genomes among individuals \
-of the cohort (present in at least 80% of samples)",
+of the cohort (present in at least 90% of samples)",
         )
 
     def test_plot_most_prevalent_taxa_boxplot_mean_threshold_mean_info(self):
@@ -681,12 +698,13 @@ of the cohort (present in at least 80% of samples)",
             show=False,
         )
 
-        expected_x_L = [0.0, 72.72727273, 91.95402299, 54.87804878]
+        expected_x_L = [0.0, 72.72727273, 91.95402299, 54.87804878, 58.82352941]
         expected_y_L = [
-            "<i>Lactobacillus</i> (genus) (mean=8.25)",
-            "<i>Lactobacillus</i> (genus) (mean=8.25)",
-            "<i>Lactobacillus</i> (genus) (mean=8.25)",
-            "<i>Lactobacillus</i> (genus) (mean=8.25)",
+            "<i>Lactobacillus</i> (genus) (mean=6.80)",
+            "<i>Lactobacillus</i> (genus) (mean=6.80)",
+            "<i>Lactobacillus</i> (genus) (mean=6.80)",
+            "<i>Lactobacillus</i> (genus) (mean=6.80)",
+            "<i>Lactobacillus</i> (genus) (mean=6.80)"
         ]
 
         np.testing.assert_allclose(fig["data"][0]["x"], expected_x_L)
@@ -699,11 +717,13 @@ of the cohort (with mean among samples > 2.0)",
 
     def test_plot_most_prevalent_taxa_bargraph_mean_threshold_mean_info(self):
         fig = self.tested_instance._plot_most_prevalent_taxa_bargraph(
-            taxa_number=2, mean_threshold=2.0, mean_info=True, show=False
+            taxa_number=2, 
+            mean_threshold=2.0,     # keep only Lactobacillus (genus)
+            mean_info=True, show=False
         )
 
-        expected_x = [75.0]
-        expected_y = ["<i>Lactobacillus</i> (genus) (mean=8.25)"]
+        expected_x = [80.0]
+        expected_y = ["<i>Lactobacillus</i> (genus) (mean=6.80)"]
 
         np.testing.assert_allclose(fig["data"][0]["x"], expected_x)
         np.testing.assert_array_equal(fig["data"][0]["y"], expected_y)
@@ -720,9 +740,9 @@ of the cohort (with mean among samples > 2.0)",
             plotting_options={"xaxes": {"type": "log"}},
         )
 
-        expected_x = [75.0, 100.0]
+        expected_x = [80.0, 100.0]
         expected_y = [
-            "<i>Lactobacillus</i> (genus)",  # with Streptococcus_salivarius and Streptococcus (genus) all at 75%
+            "<i>Lactobacillus</i> (genus)",
             "<i>Streptococcus thermophilus</i>",
         ]
 
@@ -753,16 +773,16 @@ You may want to try to lower your threshold(s).",
 
     def test_plot_most_abundant_taxa_invalidmode(self):
         # If the mode is invalid, the graph will be plotted as a bargraph, which is the default mode
-        expected_x = [20.14751170238975, 7.8215077605321515]
+        expected_x = [16.1180093619118, 13.111221884239251]
         expected_y = [
             "<i>Streptococcus salivarius</i>",
-            "<i>Actinobaculum massiliense</i>",
+            "<i>Streptococcus thermophilus</i>",
         ]
 
         with self.assertLogs("moonstone.plot.counts", level="WARNING") as log:
             fig = self.tested_instance.plot_most_abundant_taxa(
                 taxa_number=2,
-                higher_classification=False,
+                higher_classification=False,    # remove Lactobacillus (genus) + Streptococcus (genus)
                 ascending=True,
                 show=False,
                 mode="invalidmode",
@@ -786,15 +806,17 @@ You may want to try to lower your threshold(s).",
             plotting_options={"xaxes": {"type": "linear"}},
         )
 
-        expected_x_L = [0.0, 72.72727273, 91.95402299, 54.87804878]
+        expected_x_L = [0.0, 72.72727273, 91.95402299, 54.87804878, 58.823529412]
         expected_y_L = [
             "<i>Lactobacillus</i>",
             "<i>Lactobacillus</i>",
             "<i>Lactobacillus</i>",
             "<i>Lactobacillus</i>",
+            "<i>Lactobacillus</i>",
         ]
-        expected_x_S = [100.0, 8.18181818, 8.04597701, 32.92682927]
+        expected_x_S = [100.0, 8.18181818, 8.04597701, 32.92682927, 41.176470588]
         expected_y_S = [
+            "<i>Streptococcus</i>",
             "<i>Streptococcus</i>",
             "<i>Streptococcus</i>",
             "<i>Streptococcus</i>",
@@ -824,15 +846,17 @@ of the cohort",
             "SAMPLE_5",
             "SAMPLE_6",
             "SAMPLE_7",
+            "SAMPLE_8"
         ]
         expected_y_L = [
             0.0,
             72.72727273,
             91.95402299,
             54.87804878,
-            82.35294118,
+            58.82352941,
             92.30769231,
             87.25490196,
+            82.35294118,
         ]
         expected_y_Ss = [
             61.11111111,
@@ -842,15 +866,17 @@ of the cohort",
             0.0,
             0.0,
             12.74509804,
+            0.0
         ]
         expected_y_Others = [
             38.88888889,
             21.81818182,
             8.04597701,
             31.09756098,
-            17.64705882,
+            41.17647059,
             7.69230769,
             0.0,
+            17.64705882,
         ]
         np.testing.assert_array_equal(fig["data"][0]["x"], expected_x)
         np.testing.assert_allclose(fig["data"][0]["y"], expected_y_L)
@@ -868,39 +894,43 @@ of the cohort",
 
         expected_x = [
             "SAMPLE_1",
-            "SAMPLE_4",
             "SAMPLE_7",
             "SAMPLE_2",
-            "SAMPLE_5",
+            "SAMPLE_8",
             "SAMPLE_3",
             "SAMPLE_6",
+            "SAMPLE_4",
+            "SAMPLE_5",
         ]
         expected_y_L = [
             0.0,
-            54.87804878,
             87.25490196,
             72.72727273,
             82.35294118,
             91.95402299,
             92.30769231,
+            54.87804878,
+            58.82352941
         ]
         expected_y_Ss = [
             61.11111111,
-            14.02439024,
             12.74509804,
             5.45454545,
             0.0,
             0.0,
             0.0,
+            14.02439024,
+            0.0
         ]
         expected_y_Others = [
             38.88888889,
-            31.09756098,
             0.0,
             21.81818182,
             17.64705882,
             8.04597701,
             7.69230769,
+            31.09756098,
+            41.17647059
         ]
         np.testing.assert_array_equal(fig["data"][0]["x"], expected_x)
         np.testing.assert_allclose(fig["data"][0]["y"], expected_y_L)
@@ -908,7 +938,7 @@ of the cohort",
         np.testing.assert_allclose(fig["data"][2]["y"], expected_y_Others)
 
     def test_plot_sample_composition_most_abundant_samples_order(self):
-        samples_order = ["SAMPLE_1", "SAMPLE_3", "SAMPLE_5", "SAMPLE_7"]
+        samples_order = ["SAMPLE_1", "SAMPLE_3", "SAMPLE_8", "SAMPLE_7"]
         fig = self.samples_compo_instance.plot_sample_composition_most_abundant_taxa(
             taxa_number=2,
             cluster_samples=True,  # skipped by samples_order
@@ -959,37 +989,41 @@ of the cohort",
             "SAMPLE_1",
             "SAMPLE_2",
             "SAMPLE_7",
-            "SAMPLE_4",
-            "SAMPLE_5",
+            "SAMPLE_8",
             "SAMPLE_3",
             "SAMPLE_6",
+            "SAMPLE_4",
+            "SAMPLE_5",
         ]
         expected_y_L = [
             0.0,
             72.72727273,
             87.25490196,
-            54.87804878,
             82.35294118,
             91.95402299,
             92.30769231,
+            54.87804878,
+            58.82352941
         ]
         expected_y_Ss = [
             61.11111111,
             5.45454545,
             12.74509804,
+            0.0,
+            0.0,
+            0.0,
             14.02439024,
-            0.0,
-            0.0,
             0.0,
         ]
         expected_y_Others = [
             38.88888889,
             21.81818182,
             0.0,
-            31.09756098,
             17.64705882,
             8.04597701,
             7.69230769,
+            31.09756098,
+            41.17647059
         ]
         np.testing.assert_array_equal(fig["data"][0]["x"], expected_x)
         np.testing.assert_allclose(fig["data"][0]["y"], expected_y_L)
@@ -1013,6 +1047,7 @@ of the cohort",
             "SAMPLE_4",
             "SAMPLE_5",
             "SAMPLE_6",
+            "SAMPLE_8"
         ]
         expected_y_L = [
             0.0,
@@ -1020,8 +1055,9 @@ of the cohort",
             87.25490196,
             91.95402299,
             54.87804878,
-            82.35294118,
+            58.82352941,
             92.30769231,
+            82.35294118,
         ]
         expected_y_Ss = [
             61.11111111,
@@ -1031,6 +1067,7 @@ of the cohort",
             14.02439024,
             0.0,
             0.0,
+            0.0
         ]
         expected_y_Others = [
             38.88888889,
@@ -1038,8 +1075,9 @@ of the cohort",
             0.0,
             8.04597701,
             31.09756098,
-            17.64705882,
+            41.17647059,
             7.69230769,
+            17.64705882,
         ]
         np.testing.assert_array_equal(fig["data"][0]["x"], expected_x)
         np.testing.assert_allclose(fig["data"][0]["y"], expected_y_L)

--- a/tests/plot/test_counts.py
+++ b/tests/plot/test_counts.py
@@ -263,67 +263,48 @@ class TestPlotTaxonomyCounts(TestCase):
             expected_df,
         )
 
-    def test_prevalence_series(self):
-        expected_ser = pd.Series(
-            {
-                (
-                    "Bacteria",
-                    "Actinobacteria",
-                    "Actinobacteria",
-                    "Actinomycetales",
-                    "Actinomycetaceae",
-                    "Actinobaculum",
-                    "Actinobaculum_massiliense",
-                ): 50.0,
-                (
-                    "Bacteria",
-                    "Firmicutes",
-                    "Bacilli",
-                    "Lactobacillales",
-                    "Lactobacillaceae",
-                    "Lactobacillus",
-                    "Lactobacillus (genus)",
-                ): 75.0,
-                (
-                    "Bacteria",
-                    "Firmicutes",
-                    "Bacilli",
-                    "Lactobacillales",
-                    "Streptococcaceae",
-                    "Streptococcus",
-                    "Streptococcus (genus)",
-                ): 75.0,
-                (
-                    "Bacteria",
-                    "Firmicutes",
-                    "Bacilli",
-                    "Lactobacillales",
-                    "Streptococcaceae",
-                    "Streptococcus",
-                    "Streptococcus_thermophilus",
-                ): 100.0,
-                (
-                    "Bacteria",
-                    "Firmicutes",
-                    "Bacilli",
-                    "Lactobacillales",
-                    "Streptococcaceae",
-                    "Streptococcus",
-                    "Streptococcus_salivarius",
-                ): 75.0,
-            }
-        )
-        expected_ser.index.names = [
-            "kingdom",
-            "phylum",
-            "class",
-            "order",
-            "family",
-            "genus",
-            "species",
-        ]
+    def test_prevalence_series_species(self):
+        expected_ser = pd.Series({
+            "Actinobaculum_massiliense": 50.0,
+            "Lactobacillus (genus)": 75.0,
+            "Streptococcus (genus)": 75.0,
+            "Streptococcus_salivarius": 75.0,
+            "Streptococcus_thermophilus": 100.0,
+            })
+        expected_ser.index.name = "species"
         pd.testing.assert_series_equal(
-            self.tested_instance.prevalence_series,
+            self.tested_instance.compute_prevalence_series("species"),
+            expected_ser,
+        )
+    
+    def test_prevalence_series_genus(self):
+        tested_object = pd.DataFrame.from_dict({
+                ('genusA', 'species1'): [0, 4, 7, 5, 0, 1, 3, 0, 0, 0],
+                ('genusA', 'species2'): [1, 0, 2, 7, 2, 7, 0, 0, 1, 0],
+                ('genusB', 'species3'): [0, 0, 8, 4, 1, 3, 1, 0, 0, 0],
+                ('genusC', 'species4'): [0, 1, 4, 1, 0, 3, 1, 0, 0, 1],
+                ('genusC', 'species5'): [0, 3, 7, 9, 1, 5, 1, 0, 0, 0],
+                ('genusA', 'species6'): [1, 0, 5, 2, 0, 8, 0, 2, 1, 9],
+                ('genusC', 'species7'): [0, 0, 6, 8, 1, 6, 0, 0, 0, 0],
+                ('genusC', 'species8'): [0, 1, 2, 3, 2, 4, 1, 0, 2, 3],
+            },
+            orient='index', columns=['sample1', 'sample2', 'sample3', 'sample4', 'sample5', 'sample6', 'sample7',
+                                     'sample8', 'sample9', 'sample10']
+        )
+        tested_object.index = pd.MultiIndex.from_tuples(tested_object.index)
+        tested_object.index.names = ["genus", "species"]
+
+        expected_ser = pd.Series({
+            "genusA": 100.0,
+            "genusB": 50.0,
+            "genusC": 80.0
+        })
+        expected_ser.index.name = "genus"
+
+        tested_instance = PlotTaxonomyCounts(tested_object)
+
+        pd.testing.assert_series_equal(
+            tested_instance.compute_prevalence_series("genus"),
             expected_ser,
         )
 

--- a/tutorial/Moonstone_Tutorial.ipynb
+++ b/tutorial/Moonstone_Tutorial.ipynb
@@ -148,10 +148,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e2bfeb34-07f9-4ec1-9e4f-3753d4349363",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from moonstone.plot.counts import PlotTaxonomyCounts\n",
+    "\n",
+    "instance = PlotTaxonomyCounts(counts_dataframe)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "f67bad9f",
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig1 = instance.plot_most_prevalent_taxa(\n",
@@ -198,10 +208,11 @@
     "    sep_series=metadata_dataframe[\"SMOKER\"].replace({\"yes\": \"smoker\", \"no\": \"non smoker\"}),\n",
     "    sep_how=\"labels\",\n",
     "    output_file=None,\n",
-    "    plotting_options={\"layout\": {\"yaxis_title\": \"Relative abundance\"}}   # all moonstone's plot and graph methods allow you to give your own plotting options\n",
-    "                                                                         # it relies on the fig.update_X({*dictionary*}) methods of plotly\n",
-    "                                                                         # it should be given in a dictionary with X being the first key and then a dictionary of the\n",
-    "                                                                         # parameters to update as you would give the fig.update_X method\n",
+    "    orientation = \"h-l\",\n",
+    "    plotting_options={\"layout\": {\"height\": 600}}   # all moonstone's plot and graph methods allow you to give your own plotting options\n",
+    "                                                   # it relies on the fig.update_X({*dictionary*}) methods of plotly\n",
+    "                                                   # it should be given in a dictionary with X being the first key and then a dictionary of the\n",
+    "                                                   # parameters to update as you would give the fig.update_X method\n",
     ")"
    ]
   },
@@ -219,9 +230,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "418fe690",
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "\"\"\"\n",
@@ -322,9 +331,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "0ba78f93",
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from moonstone.plot.graphs import ScatterTrendlines\n",
@@ -355,7 +362,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.11"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Description

cf #111 

#### Changelogs

* Fixing error in the calculation of the prevalence at taxonomical level higher than species (e.g. genus etc.)
* Addition of the argument `orientation` to the `plot_one_graph()` and `plot_complex graph()` methods of the `MatrixBarGraph` class, and so to `plot_sample_composition_most_abundant_taxa()` (class `PlotTaxonomyCounts`)

#### Issue(s)

Fixes #111 

## Definition of Done

* [ ]  New code is tested with unit tests
* [ ]  Documentation has been updated
* [ ]  Pull Request has been revised by a maintainer of the project
